### PR TITLE
Add removeEventListener method to DomMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,17 @@ Passivity refers to the ability for a handler to either `preventDefault` or,
 in our implementation, `stopPropagation`. In dev mode and testing, use of
 these APIs on the event object will raise an exception.
 
+### `removeEventListener`
+
+**tl;dr call `this.removeEventListener(element, eventName, fn, options)` on a component or
+view to actively remove a jQuery event listener previously added by a call to `addEventListener`.**
+
+Although any listener added by a call to `addEventListener` will be teared down when the view or component is being
+destroyed, there might be cases where you want to actively remove an existing event listener even during the active
+lifecycle, for example when temporarily dealing with high volume events like `scroll` or `mousemove`.
+
+Be sure to pass the identical arguments used when calling `addEventListener`!
+
 ## Credit
 
 This addon was developed internally at Twitch, written originally by [@mixonic](https://github.com/mixonic) and [@rwjblue](https://github.com/rwjblue).

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -278,6 +278,26 @@ moduleForComponent('ember-lifeline/mixins/dom', {
     assert.equal(calls, 3, 'one more callback called for remaining context');
   });
 
+  test(`${testName.replace('add', 'remove')} removes event listener from child element`, function(assert) {
+    assert.expect(1);
+
+    this.register('template:components/under-test', hbs`<span class="foo"></span>`);
+    this.render(hbs`{{under-test}}`);
+    let subject = this.componentInstance;
+
+    let calls = 0;
+    let listener = () => {
+      calls++;
+    };
+    subject.addEventListener('.foo', 'click', listener, testedOptions);
+
+    subject.removeEventListener('.foo', 'click', listener, testedOptions);
+
+    subject.element.firstChild.dispatchEvent(new Event('click'));
+
+    assert.equal(calls, 0, 'callback was not called');
+  });
+
 });
 
 test('addEventListener(_,_) coalesces multiple listeners on same event', function(assert) {


### PR DESCRIPTION
I had the need to remove an event listener during the active lifecycle of a component. This can happen especially for high volume events like `scroll` or `mousemove`, where you maybe want to listen to them conditionally, not all the time.

This adds the matching `removeEventListener` method to the `DomMixin`.

Added a test just for one simple case (with and without the `passive` flag), not all the different cases you have provided for `addEventListener`. Not sure if that makes sense to duplicate all of them also for `removeEventListener`? If you want me to do that, just tell me!
