### PR TITLE
Remove references to web-client in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,9 @@ tests that are not related to the polling behavior to continue uninterrupted. To
 functionality, use the provided `pollTaskFor` helper:
 
 ```js
-import moduleForComponent from 'web-client/tests/helpers/module-for-component';
+import moduleForComponent from 'ember-lifeline/tests/helpers/module-for-component';
 import wait from 'ember-test-helpers/wait';
-import { pollTaskFor } from 'web-client/mixins/context-bound-tasks';
+import { pollTaskFor } from 'ember-lifeline/mixins/run';
 import Service from 'ember-service';
 
 let fakeNow;

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -99,7 +99,7 @@ export default Mixin.create({
 
    ```js
    import Component from 'ember-component';
-   import ContextBoundEventListenersMixin from 'web-client/mixins/context-bound-event-listeners';
+   import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 
    export default Component.extend(ContextBoundEventListenersMixin, {
      didInsertElement() {

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -57,7 +57,7 @@ export default Mixin.create({
 
    ```js
    import Component from 'ember-component';
-   import ContextBoundTasksMixin from 'web-client/mixins/context-bound-tasks';
+   import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 
    export default Component.extend(ContextBoundTasksMixin, {
      didInsertElement() {
@@ -103,7 +103,7 @@ export default Mixin.create({
 
    ```js
    import Component from 'ember-component';
-   import ContextBoundTasksMixin from 'web-client/mixins/context-bound-tasks';
+   import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 
    export default Component.extend(ContextBoundTasksMixin, {
      logMe() {
@@ -153,7 +153,7 @@ export default Mixin.create({
 
    ```js
    import Component from 'ember-component';
-   import ContextBoundTasksMixin from 'web-client/mixins/context-bound-tasks';
+   import ContextBoundTasksMixin from 'ember-lifeline/mixins/run';
 
    export default Component.extend(ContextBoundTasksMixin, {
      logMe() {
@@ -210,7 +210,7 @@ export default Mixin.create({
 
    ```js
    import wait from 'ember-test-helpers/wait';
-   import { pollTaskFor } from 'web-client/mixins/context-bound-tasks';
+   import { pollTaskFor } from 'ember-lifeline/mixins/run';
 
    //...snip...
 


### PR DESCRIPTION
Looks like some restructuring happened and the docs were outdated.