### PR TITLE
[Bugfix] - Adding assertions to ensure _super has been called

### DIFF
--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -119,6 +119,7 @@ export default Mixin.create({
   addEventListener(selector, eventName, callback, _options) {
     assert('Must provide an element (not a jQuery selector) when using addEventListener in a tagless component.', this.tagName !== '' || typeof selector !== 'string');
     assert('Called addEventListener before the component was rendered', this._currentState === this._states.inDOM);
+    assert(`Called \`addEventListener\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._listeners !== 'undefined');
 
     // Ember.assign would be better here, but Ember < 2.5 doesn't have that :(
     let options = merge(merge({}, DEFAULT_LISTENER_OPTIONS), _options);
@@ -140,6 +141,7 @@ export default Mixin.create({
    */
   removeEventListener(selector, eventName, callback, _options) {
     assert('Must provide an element (not a jQuery selector) when using addEventListener in a tagless component.', this.tagName !== '' || typeof selector !== 'string');
+    assert(`Called \`removeEventListener\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._listeners !== 'undefined');
 
     let options = merge(merge({}, DEFAULT_LISTENER_OPTIONS), _options);
     let element = findElement(this.element, selector);
@@ -238,6 +240,8 @@ export default Mixin.create({
 
   willDestroyElement() {
     this._super(...arguments);
+
+    assert(`Called \`willDestroyElement\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._listeners !== 'undefined');
 
     /* Drop non-passive event listeners */
     for (let i = 0; i < this._listeners.length; i++) {

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -119,7 +119,7 @@ export default Mixin.create({
   addEventListener(selector, eventName, callback, _options) {
     assert('Must provide an element (not a jQuery selector) when using addEventListener in a tagless component.', this.tagName !== '' || typeof selector !== 'string');
     assert('Called addEventListener before the component was rendered', this._currentState === this._states.inDOM);
-    assert(`Called \`addEventListener\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._listeners !== 'undefined');
+    assert(`Called \`addEventListener\` without \`init\` calling \`_super\` in ${this}. Please ensure \`init\` is calling \`_super\`.`, typeof this._listeners !== 'undefined');
 
     // Ember.assign would be better here, but Ember < 2.5 doesn't have that :(
     let options = merge(merge({}, DEFAULT_LISTENER_OPTIONS), _options);
@@ -141,7 +141,7 @@ export default Mixin.create({
    */
   removeEventListener(selector, eventName, callback, _options) {
     assert('Must provide an element (not a jQuery selector) when using addEventListener in a tagless component.', this.tagName !== '' || typeof selector !== 'string');
-    assert(`Called \`removeEventListener\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._listeners !== 'undefined');
+    assert(`Called \`removeEventListener\` without \`init\` calling \`_super\` in ${this}. Please ensure \`init\` is calling \`_super\`.`, typeof this._listeners !== 'undefined');
 
     let options = merge(merge({}, DEFAULT_LISTENER_OPTIONS), _options);
     let element = findElement(this.element, selector);
@@ -241,7 +241,7 @@ export default Mixin.create({
   willDestroyElement() {
     this._super(...arguments);
 
-    assert(`Called \`willDestroyElement\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._listeners !== 'undefined');
+    assert(`Called \`willDestroyElement\` without \`init\` calling \`_super\` in ${this}. Please ensure \`init\` is calling \`_super\`.`, typeof this._listeners !== 'undefined');
 
     /* Drop non-passive event listeners */
     for (let i = 0; i < this._listeners.length; i++) {

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -75,6 +75,8 @@ export default Mixin.create({
    */
   runTask(callbackOrName, timeout = 0) {
     assert(`Called \`runTask\` on destroyed object: ${this}.`, !this.isDestroyed);
+    assert(`Called \`runTask\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._pendingTimers !== 'undefined');
+
     let type = typeof callbackOrName;
 
     let cancelId = run.later(() => {
@@ -271,6 +273,8 @@ export default Mixin.create({
 
   willDestroy() {
     this._super(...arguments);
+
+    assert(`Called \`willDestroy\` without \`init\` being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._pendingTimers !== 'undefined');
 
     cancelTimers(this._pendingTimers);
     cancelDebounces(this._pendingDebounces);

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -75,7 +75,7 @@ export default Mixin.create({
    */
   runTask(callbackOrName, timeout = 0) {
     assert(`Called \`runTask\` on destroyed object: ${this}.`, !this.isDestroyed);
-    assert(`Called \`runTask\` without init being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._pendingTimers !== 'undefined');
+    assert(`Called \`runTask\` without \`init\` calling \`_super\` in ${this}. Please ensure \`init\` is calling \`_super\`.`, typeof this._pendingTimers !== 'undefined');
 
     let type = typeof callbackOrName;
 
@@ -274,7 +274,7 @@ export default Mixin.create({
   willDestroy() {
     this._super(...arguments);
 
-    assert(`Called \`willDestroy\` without \`init\` being called in ${this}. Please ensure init is calling \`_super\`.`, typeof this._pendingTimers !== 'undefined');
+    assert(`Called \`willDestroy\` without \`init\` calling \`_super\` in ${this}. Please ensure \`init\` is calling \`_super\`.`, typeof this._pendingTimers !== 'undefined');
 
     cancelTimers(this._pendingTimers);
     cancelDebounces(this._pendingDebounces);

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -10,16 +10,18 @@ moduleForComponent('ember-lifeline/mixins/dom', {
   integration: true,
 
   beforeEach() {
-    let owner = getOwner(this);
     let testContext = this;
-    owner.register('component:under-test', Component.extend(ContextBoundEventListenersMixin, {
+    let name = 'component:under-test';
+
+    this.owner = getOwner(this);
+    this.owner.register(name, Component.extend(ContextBoundEventListenersMixin, {
       init() {
         this._super(...arguments);
         testContext.componentInstance = this;
       }
     }));
 
-    this.Component = owner._lookupFactory('component:under-test');
+    this.Component = this.owner.factoryFor ? this.container.factoryFor(name) : this.owner._lookupFactory(name);
     setShouldAssertPassive(true);
   }
 });

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -21,7 +21,7 @@ moduleForComponent('ember-lifeline/mixins/dom', {
       }
     }));
 
-    this.Component = this.owner.factoryFor ? this.container.factoryFor(name) : this.owner._lookupFactory(name);
+    this.Component = this.owner.factoryFor ? this.owner.factoryFor(name) : this.owner._lookupFactory(name);
     setShouldAssertPassive(true);
   }
 });

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -124,6 +124,19 @@ test('runTask tasks can be canceled', function(assert) {
   }, 10);
 });
 
+test('runTask triggers an assertion when init has not called _super in the super chain', function(assert) {
+  let subject = this.subject({
+    init() {
+    },
+    willDestroy() {
+    }
+  });
+
+  assert.throws(() => {
+    subject.runTask(() => {}, 5);
+  }, /without \`init\` calling \`_super\`/);
+});
+
 test('throttleTask triggers an assertion when a string is not the first argument', function(assert) {
   let subject = this.subject({
     doStuff() {}


### PR DESCRIPTION
If `_super` has not been called within the init chain for classes/mixins utilizing the `ContextBoundTasksMixin` and the `ContextBoundEventListenersMixin` the calls to `willDestroy` will error out due to the members within those mixins not being initialized. This PR adds assertions to identify those classes.

**Reviewers**:
@rwjblue 

**Changes**:
- Added assertions in both run.js and dom.js to identify classes that haven't called `_super` in `init`.

