### PR TITLE
Fix scope of coalesced event listeners

### DIFF
--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -151,7 +151,8 @@ export default Mixin.create({
     }
   },
 
-  _addCoalescedEventListener(element, eventName, callback) {
+  _addCoalescedEventListener(element, eventName, _callback) {
+    let callback = run.bind(this, _callback);
     /*
      * listenerData caches the handler list and listener callback on the
      * element as a property.
@@ -194,7 +195,7 @@ export default Mixin.create({
      * teardown.
      */
     listenerData.handlers.push(callback);
-    this._coalescedHandlers.push({ element, eventName, callback });
+    this._coalescedHandlers.push({ element, eventName, callback, _callback });
   },
 
   _addEventListener(element, eventName, _callback) {
@@ -203,13 +204,13 @@ export default Mixin.create({
     this._listeners.push({ element, eventName, callback, _callback });
   },
 
-  _removeCoalescedEventListener(element, eventName, callback) {
+  _removeCoalescedEventListener(element, eventName, _callback) {
     for (let i = 0; i < this._coalescedHandlers.length; i++) {
       let handler = this._coalescedHandlers[i];
       if (
         handler.element.get(0) === element.get(0)
         && handler.eventName === eventName
-        && handler.callback === callback
+        && handler._callback === _callback
       ) {
         removeHandlerFromListenerData(handler);
         break;

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -278,6 +278,40 @@ moduleForComponent('ember-lifeline/mixins/dom', {
     assert.equal(calls, 3, 'one more callback called for remaining context');
   });
 
+  test(`${testName} listeners are called with correct scope`, function(assert) {
+    assert.expect(2);
+
+    let testContext = this;
+    this.register('component:under-test-a', Component.extend(ContextBoundEventListenersMixin, {
+      init() {
+        this._super(...arguments);
+        testContext.subjectA = this;
+      }
+    }));
+    this.register('component:under-test-b', Component.extend(ContextBoundEventListenersMixin, {
+      init() {
+        this._super(...arguments);
+        testContext.subjectB = this;
+      }
+    }));
+
+    this.render(hbs`{{under-test-a}}{{under-test-b}}<span class="foo"></span>`);
+
+    let { subjectA, subjectB } = this;
+
+    let target = this.$('.foo');
+
+    let assertScope = (scope) => {
+      return function() {
+        assert.equal(this, scope);
+      };
+    };
+    subjectA.addEventListener(target, 'click', assertScope(subjectA), testedOptions);
+    subjectB.addEventListener(target, 'click', assertScope(subjectB), testedOptions);
+
+    target.click();
+  });
+
   test(`${testName.replace('add', 'remove')} removes event listener from child element`, function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
While the scope of event handlers was correctly bound (`run.bind`) to the component instance adding the listener for non-passive listeners, for coalesced/passive listeners (on the same DOM element, e.g. `body`) this was not the case. So when using `this` in a listener, this could be a completely different component instance! (fwiw probably the first component calling `_addCoalescedEventListener` and thus attaching the `coalescedCallback` for that given element).

This fixes it and adds a corresponding test!