### PR TITLE
Introduce cancelers

### DIFF
--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -354,17 +354,17 @@ export default Mixin.create({
      },
 
      disableAutoRefresh() {
-        this.clearPoller('foo-bar#watch-some-path');
+        this.cancelPoll('foo-bar#watch-some-path');
      }
    });
    ```
 
-   @method clearPoller
+   @method cancelPoll
    @param { String } label the label for the pollTask to be cleared
    @public
    */
-  clearPoller(label) {
-    clearPoller(label);
+  cancelPoll(label) {
+    cancelPoll(label);
   },
 
   willDestroy() {
@@ -398,11 +398,11 @@ function clearPollers(labels) {
   }
 
   for (let i = 0; i < labels.length; i++) {
-    clearPoller(labels[i]);
+    cancelPoll(labels[i]);
   }
 }
 
-function clearPoller(label) {
+function cancelPoll(label) {
   pollTaskLabels[label] = undefined;
   queuedPollTasks[label] = undefined;
 }
@@ -421,19 +421,19 @@ function cancelTimer(cancelId) {
   run.cancel(cancelId);
 }
 
-function cancelDebounces(obj) {
-  let debounceNames = obj && Object.keys(obj);
+function cancelDebounces(pendingDebounces) {
+  let debounceNames = pendingDebounces && Object.keys(pendingDebounces);
 
   if (!debounceNames || !debounceNames.length) {
     return;
   }
 
   for (let i = 0; i < debounceNames.length; i++) {
-    cancelDebounce(obj, debounceNames[i]);
+    cancelDebounce(pendingDebounces, debounceNames[i]);
   }
 }
 
-function cancelDebounce(obj, name) {
-  let { cancelId } = obj[name];
+function cancelDebounce(pendingDebounces, name) {
+  let { cancelId } = pendingDebounces[name];
   run.cancel(cancelId);
 }

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.3",
     "eslint-plugin-ember-suave": "^1.0.0",
-    "loader.js": "^4.0.10",
-    "phantomjs": "^2.1.7"
+    "loader.js": "^4.0.10"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.3",
     "eslint-plugin-ember-suave": "^1.0.0",
-    "loader.js": "^4.0.10"
+    "loader.js": "^4.0.10",
+    "phantomjs": "^2.1.7"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -122,11 +122,11 @@ test('runTask tasks can be canceled', function(assert) {
   let done = assert.async();
   let hasRun = false;
 
-  let timer = subject.runTask(() => {
+  let cancelId = subject.runTask(() => {
     hasRun = true;
   }, 5);
 
-  run.cancel(timer);
+  subject.cancelTask(cancelId);
 
   window.setTimeout(() => {
     assert.notOk(hasRun, 'callback should have been canceled previously');
@@ -192,6 +192,29 @@ test('debounceTask should cancel properly on teardown', function(assert) {
   subject.debounceTask('doStuff', 5);
   subject.debounceTask('doStuff', 5);
   run(subject, 'destroy');
+
+  assert.equal(runCount, 0, 'should not have run');
+
+  window.setTimeout(() => {
+    assert.equal(runCount, 0, 'should not have run');
+    done();
+  }, 10);
+});
+
+test('debounceTask can be canceled', function(assert) {
+  let done = assert.async();
+  assert.expect(2);
+
+  let runCount = 0;
+  let subject = this.subject({
+    doStuff() {
+      runCount++;
+    }
+  });
+
+  subject.debounceTask('doStuff', 5);
+  subject.debounceTask('doStuff', 5);
+  subject.cancelDebounce('doStuff');
 
   assert.equal(runCount, 0, 'should not have run');
 
@@ -425,6 +448,34 @@ test('pollTask: does not leak when destroyed', function(assert) {
   }, 'one');
 
   run(subject, 'destroy');
+
+  assert.throws(() => {
+    pollTaskFor('one');
+  }, /A pollTask with a label of 'one' was not found/);
+
+  subject = this.subject({ force: true });
+
+  subject.pollTask((next) => {
+    assert.ok(true, 'pollTask was called');
+    subject.runTask(next, 5);
+  }, 'one');
+
+  // ensure that pending pollTask's are not running
+  return wait()
+    .then(() => {
+      pollTaskFor('one');
+    });
+});
+
+test('pollTask: can be manually cleared', function(assert) {
+  assert.expect(3);
+  let subject = this.subject();
+
+  subject.pollTask((next) => {
+    subject.runTask(next);
+  }, 'one');
+
+  subject.clearPoller('one');
 
   assert.throws(() => {
     pollTaskFor('one');

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -475,7 +475,7 @@ test('pollTask: can be manually cleared', function(assert) {
     subject.runTask(next);
   }, 'one');
 
-  subject.clearPoller('one');
+  subject.cancelPoll('one');
 
   assert.throws(() => {
     pollTaskFor('one');


### PR DESCRIPTION
This PR introduces 3 methods for manually cancelling scheduled work:
- `this.cancelTask(cancelId)`
- `this.cancelDebounce(name)`
- `this.clearPoller(name)`

Closes #30 