### PR TITLE
Cleanup throttled functions in willDestroy

### DIFF
--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -208,6 +208,10 @@ export default Mixin.create({
     cancelDebounce(this._pendingDebounces, name);
   },
 
+  cancelThrottle(cancelId) {
+    cancelThrottle(cancelId);
+  },
+
   /**
    Runs the function with the provided name immediately, and only once in the time window
    specified by the timeout argument.
@@ -239,7 +243,13 @@ export default Mixin.create({
     assert(`Called \`this.throttleTask('${name}', ${timeout})\` where 'this.${name}' is not a function.`, typeof this[name] === 'function');
     assert(`Called \`throttleTask\` on destroyed object: ${this}.`, !this.isDestroyed);
 
-    run.throttle(this, name, timeout);
+    let pendingThrottles = getOrAllocate(this, '_pendingThrottles', Array);
+
+    let cancelId = run.throttle(this, name, timeout);
+
+    pendingThrottles.push(cancelId);
+
+    return cancelId;
   },
 
   /**
@@ -370,6 +380,7 @@ export default Mixin.create({
 
     cancelTimers(this._pendingTimers);
     cancelDebounces(this._pendingDebounces);
+    cancelThrottles(this._pendingThrottles);
     clearPollers(this._pollerLabels);
   }
 });
@@ -417,5 +428,19 @@ function cancelDebounces(pendingDebounces) {
 
 function cancelDebounce(pendingDebounces, name) {
   let { cancelId } = pendingDebounces[name];
+  run.cancel(cancelId);
+}
+
+function cancelThrottles(pendingThrottles) {
+  if (!pendingThrottles || !pendingThrottles.length) {
+    return;
+  }
+
+  for (let i = 0; i < pendingThrottles.length; i++) {
+    cancelThrottle(pendingThrottles[i]);
+  }
+}
+
+function cancelThrottle(cancelId) {
   run.cancel(cancelId);
 }

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -44,6 +44,7 @@ export default Mixin.create({
 
     this._pendingTimers = undefined;
     this._pendingDebounces = undefined;
+    this._pendingThrottles = undefined;
     this._pollerLabels = undefined;
   },
 

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -10,7 +10,6 @@ setResolver(resolver);
 start();
 
 const TESTS_WITH_LEAKY_ASYNC = [];
-// eslint-disable-next-line ember-suave/no-const-outside-module-scope
 const { run } = Ember;
 
 QUnit.testDone(({ module, name }) => {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,6 @@
+import Ember from 'ember';
 import resolver from './helpers/resolver';
+import QUnit from 'qunit';
 import {
   setResolver
 } from 'ember-qunit';
@@ -6,3 +8,20 @@ import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);
 start();
+
+const TESTS_WITH_LEAKY_ASYNC = [];
+// eslint-disable-next-line ember-suave/no-const-outside-module-scope
+const { run } = Ember;
+
+QUnit.testDone(({ module, name }) => {
+  if (run.hasScheduledTimers()) {
+    TESTS_WITH_LEAKY_ASYNC.push(`${module}: ${name}`);
+    run.cancelTimers();
+  }
+});
+
+QUnit.done(() => {
+  if (TESTS_WITH_LEAKY_ASYNC.length > 0) {
+    throw new Error(`*****ASYNC LEAKAGE DETECTED!!!!***** The following (${TESTS_WITH_LEAKY_ASYNC.length}) tests setup a timer that was never torn down: \n${TESTS_WITH_LEAKY_ASYNC.join('\n')}`);
+  }
+});

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -173,22 +173,14 @@ test('throttleTask can be canceled', function(assert) {
   }, 10);
 });
 
-test('No timers exist after throttled task is canceled', function(assert) {
-  assert.expect(2);
-
-  // eslint-disable-next-line ember-suave/no-const-outside-module-scope
-  const { run } = Ember;
+test('No error should be thrown by QUnit (throttles should be cleaned up)', function(assert) {
+  assert.expect(0);
 
   let subject = this.subject({
-    doStuff() {
-    }
+    doStuff() {}
   });
 
-  let cancelId = subject.throttleTask('doStuff', 5, false);
-
-  assert.ok(run.hasScheduledTimers(), 'Timers setup');
-  subject.cancelThrottle(cancelId);
-  assert.notOk(run.hasScheduledTimers(), 'Timers cancelled');
+  subject.throttleTask('doStuff', 5);
 });
 
 test('debounceTask runs tasks', function(assert) {

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -151,6 +151,27 @@ test('throttleTask triggers an assertion the function name provided does not exi
   }, /is not a function/);
 });
 
+test('throttleTask can be canceled', function(assert) {
+  assert.expect(1);
+
+  let done = assert.async();
+  let runCount = 0;
+  let subject = this.subject({
+    doStuff() {
+      runCount++;
+    }
+  });
+
+  let cancelId = subject.throttleTask('doStuff', 5, false);
+  subject.cancelThrottle(cancelId);
+  subject.throttleTask('doStuff', 5, false);
+
+  window.setTimeout(() => {
+    assert.equal(runCount, 2, 'callback should have been canceled previously');
+    done();
+  }, 10);
+});
+
 test('debounceTask runs tasks', function(assert) {
   assert.expect(3);
 

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
@@ -170,6 +171,24 @@ test('throttleTask can be canceled', function(assert) {
     assert.equal(runCount, 2, 'callback should have been canceled previously');
     done();
   }, 10);
+});
+
+test('No timers exist after throttled task is canceled', function(assert) {
+  assert.expect(2);
+
+  // eslint-disable-next-line ember-suave/no-const-outside-module-scope
+  const { run } = Ember;
+
+  let subject = this.subject({
+    doStuff() {
+    }
+  });
+
+  let cancelId = subject.throttleTask('doStuff', 5, false);
+
+  assert.ok(run.hasScheduledTimers(), 'Timers setup');
+  subject.cancelThrottle(cancelId);
+  assert.notOk(run.hasScheduledTimers(), 'Timers cancelled');
 });
 
 test('debounceTask runs tasks', function(assert) {


### PR DESCRIPTION
Throttled functions aren't getting cleaned up in willDestroy, while other timers and debounced methods are being cleaned up.