### PR TITLE
De-duping cancel functions

### DIFF
--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -5,7 +5,8 @@ import wait from 'ember-test-helpers/wait';
 
 import ContextBoundTasksMixin, {
   setShouldPoll,
-  pollTaskFor
+  pollTaskFor,
+  cancelBoundTasks
 } from 'ember-lifeline/mixins/run';
 
 module('ember-lifeline/mixins/run', {
@@ -523,4 +524,47 @@ test('pollTask: can be manually cleared', function(assert) {
     .then(() => {
       pollTaskFor('one');
     });
+});
+
+test('cancelBoundTasks: early returns if tasks is falsey', function(assert) {
+  assert.expect(1);
+
+  let tasks = null;
+  let callCount = 0;
+  let cancelFn = () => {
+    callCount++;
+  };
+
+  cancelBoundTasks(tasks, cancelFn);
+
+  assert.equal(callCount, 0, 'The cancel function should not have been called');
+});
+
+test('cancelBoundTasks: early returns if tasks is an empty array', function(assert) {
+  assert.expect(1);
+
+  let tasks = [];
+  let callCount = 0;
+  let cancelFn = () => {
+    callCount++;
+  };
+
+  cancelBoundTasks(tasks, cancelFn);
+
+  assert.equal(callCount, 0, 'The cancel function should not have been called');
+});
+
+test('cancelBoundTasks: cancel function is called once for each task', function(assert) {
+  assert.expect(4);
+
+  let tasks = ['one', 'two', 'three'];
+  let callCount = 0;
+  let cancelFn = (task) => {
+    assert.equal(task, tasks[callCount], 'The cancel function receives the correct param');
+    callCount++;
+  };
+
+  cancelBoundTasks(tasks, cancelFn);
+
+  assert.equal(callCount, 3, 'The cancel function is called 3 times');
 });


### PR DESCRIPTION
The logic within each of the cancel functions is virtually identical. This PR de-dupes them to DRY things up.

Also adds tests for the cancel logic, as simple as it is.