### PR TITLE
Allow calling addEventListener from non component entities (services,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,30 @@ In this example, the first click will update `time`, but clicks after that
 for 500ms will be disregarded. Then, the next click will fire and start
 a timeout window of its own.
 
+Often it is desired to pass additional arguments to the throttle callback. We
+also need to reference the same function in order for throttling to work. In
+order to acheive this it is recommended to make use of instance variables. This
+enables the throttle function to use the arguments in the state they are in
+at the time the callback is executed:
+
+```js
+import Ember from 'ember';
+import RunMixin from 'ember-lifeline/mixins/run';
+
+const { Component } = Ember;
+
+export default Component.extend(RunMixin, {
+  click(evt) {
+    this._evt = evt;
+    this.throttleTask('updateClickedEl', 500);
+  },
+  updateClickedEl() {
+    this.set('lastClickedEl', this._evt.target);
+  }
+});
+```
+
+
 ### `pollTask`
 
 **tl;dr call `this.pollTask(fn, label)` on any component, route, or service to setup

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ export default Component.extend(RunMixin, {
   },
   updateClickedEl() {
     this.set('lastClickedEl', this._evt.target);
+    this._evt = null;
   }
 });
 ```

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -61,8 +61,14 @@ export default Mixin.create({
    @public
    */
   addEventListener(selector, eventName, _callback, options) {
-    assert('Must provide an element (not a DOM selector) when using addEventListener in a tagless component.', this.tagName !== '' || typeof selector !== 'string');
-    assert('Called addEventListener before the component was rendered', this._currentState === this._states.inDOM);
+    assert(
+      'Must provide an element (not a DOM selector) when using addEventListener in a tagless entity.',
+      this.tagName || typeof selector !== 'string'
+    );
+    assert(
+      'Called addEventListener before the component was rendered',
+      !(this.tagName && typeof selector === 'string') || this._currentState === this._states.inDOM
+    );
 
     let element = findElement(this.element, selector);
     let callback = run.bind(this, _callback);

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -54,6 +54,24 @@ export default Mixin.create({
    });
    ```
 
+   This can also be used in other ember types like services and controllers. In
+   order to use it there an html element reference must be used instead of a
+   css selector. This way we can be sure the element actually exists when the
+   listener is attached:
+
+   ```js
+   import Service from 'ember-service';
+   import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
+
+   export default Service.extend(ContextBoundEventListenersMixin, {
+     init() {
+       this._super(...arguments);
+       const el = document.querySelector('.foo');
+       this.addEventListener(el, 'click')
+     }
+   });
+   ```
+
    @method addEventListener
    @param { String } selector the DOM selector or element
    @param { String } _eventName the event name to listen for
@@ -61,14 +79,12 @@ export default Mixin.create({
    @public
    */
   addEventListener(selector, eventName, _callback, options) {
-    assert(
-      'Must provide an element (not a DOM selector) when using addEventListener in a tagless entity.',
-      this.tagName || typeof selector !== 'string'
-    );
-    assert(
-      'Called addEventListener before the component was rendered',
-      !(this.tagName && typeof selector === 'string') || this._currentState === this._states.inDOM
-    );
+    assert('Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
+      !this.isComponent || this.tagName !== '' || typeof selector !== 'string');
+    assert('Called addEventListener with a css selector before the component was rendered',
+      !this.isComponent || typeof selector !== 'string' || this._currentState === this._states.inDOM);
+    assert('Must provide an element (not a DOM selector) when calling addEventListener outside of component instance.',
+      this.isComponent || typeof selector !== 'string');
 
     let element = findElement(this.element, selector);
     let callback = run.bind(this, _callback);

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -309,7 +309,8 @@ moduleForComponent('ember-lifeline/mixins/dom', {
       }
     }));
 
-    let subject = owner.factoryFor(serviceName).create();
+    let factory = owner.factoryFor ? owner.factoryFor(serviceName) : owner._lookupFactory(serviceName);
+    let subject = factory.create();
 
     this.render(hbs`<span class="foo"></span>`);
 

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -18,7 +18,6 @@ moduleForComponent('ember-lifeline/mixins/dom', {
 
     this.owner = getOwner(this);
     this.owner.register(name, Component.extend(ContextBoundEventListenersMixin, {
-      tagName: 'div',
       init() {
         this._super(...arguments);
         testContext.componentInstance = this;
@@ -155,7 +154,7 @@ moduleForComponent('ember-lifeline/mixins/dom', {
 
     assert.throws(() => {
       subject.addEventListener('.foo', 'click', () => {}, testedOptions);
-    }, /Called \w+ before the component was rendered/);
+    }, /Called \w+ with a css selector before the component was rendered/);
   });
 
   test(`${testName} adds event listener to non-child element in tagless component`, async function(assert) {
@@ -323,6 +322,22 @@ moduleForComponent('ember-lifeline/mixins/dom', {
     assert.ok(hadRunloop, 'callback was called in runloop');
     assert.ok(!!handledEvent.target, 'callback passed a target');
     assert.equal(handledEvent.target.className, 'foo', 'target has the expected class');
+  });
+
+  test(`${testName} throws when a css selector is passed in from a service instance`, async function(assert) {
+    assert.expect(1);
+
+    let serviceName = 'service:under-test';
+    let owner = getOwner(this);
+
+    owner.register('service:under-test', Service.extend(ContextBoundEventListenersMixin));
+
+    let factory = owner.factoryFor ? owner.factoryFor(serviceName) : owner._lookupFactory(serviceName);
+    let subject = factory.create();
+
+    assert.throws(() => {
+      subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+    }, /Must provide an element/);
   });
 });
 

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -298,16 +298,10 @@ moduleForComponent('ember-lifeline/mixins/dom', {
   test(`${testName} adds event listener when an element is passed in from a service instance`, async function(assert) {
     assert.expect(4);
 
-    let testContext = this;
     let serviceName = 'service:under-test';
     let owner = getOwner(this);
 
-    owner.register(serviceName, Service.extend(ContextBoundEventListenersMixin, {
-      init() {
-        this._super(...arguments);
-        testContext.componentInstance = this;
-      }
-    }));
+    owner.register('service:under-test', Service.extend(ContextBoundEventListenersMixin));
 
     let factory = owner.factoryFor ? owner.factoryFor(serviceName) : owner._lookupFactory(serviceName);
     let subject = factory.create();


### PR DESCRIPTION
- add documentation for using instance variables to pass information to the throttle callback
- Update assert logic in addEventListener to support calling from non-component entities
- Fix a subtle bug in the previous assert logic whereby a null tagName property would pass the test for existing tagName when it should not.
- Also discovered that the tagName property was not being set automagically on the test component instances for some reason
- Add a new test to make sure the assert logic now properly accounts for non-component entities using the dom mixin