### PR TITLE
document using this.element with addEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,9 @@ this.addEventListener('.someClass', 'scroll', fn);
 // Attach to a DOM node
 this.addEventListener(document.body, 'click', fn);
 
+// Attach to a component's root element
+this.addEventListener(this.element, 'scroll', fn);
+
 // Attach to window
 this.addEventListener(window, 'scroll', fn);
 ```


### PR DESCRIPTION
This would have saved me a few minutes of head scratching when upgrading from the old jQuery-compatible API (`this.addEventListener(this.$(), 'scroll', fn);`)