### PR TITLE
Refactor to Weakmaps Part 3 - DOM to disposable

### DIFF
--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -5,6 +5,13 @@ import { registerDisposable } from './utils/disposable';
 
 const { WeakMap } = Ember;
 
+/**
+ * A map of instances/listeners that allows us to
+ * store listener references per instance.
+ *
+ * @private
+ *
+ */
 const eventListeners = new WeakMap();
 
 const PASSIVE_SUPPORTED = (() => {
@@ -92,6 +99,14 @@ export function addEventListener(obj, selector, eventName, _callback, options) {
     'Must provide an element (not a DOM selector) when calling addEventListener outside of component instance.',
     obj.isComponent || typeof selector !== 'string'
   );
+
+  // If no element is provided, we assume we're adding the event listener to the component's element. This
+  // addresses use cases where we want to bind events like `scroll` to the component's root element.
+  if (obj.isComponent && typeof eventName === 'function') {
+    _callback = eventName;
+    eventName = selector;
+    selector = obj.element;
+  }
 
   let element = findElement(obj.element, selector);
   let callback = run.bind(obj, _callback);

--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { assert } from '@ember/debug';
 import { run } from '@ember/runloop';
 import { registerDisposable } from './utils/disposable';
 
@@ -84,8 +85,13 @@ const INDEX = {
    @public
    */
 export function addEventListener(obj, element, eventName, _callback, options) {
-  let callback = run.bind(obj, _callback);
+  assert('Must provide a DOM element when using addEventListener', !!element);
+  assert(
+    'Must provide an element (not a DOM selector) when using addEventListener.',
+    element instanceof Element
+  );
 
+  let callback = run.bind(obj, _callback);
   let listeners = getEventListeners(obj);
 
   if (!PASSIVE_SUPPORTED) {
@@ -110,6 +116,15 @@ export function removeEventListener(
   callback,
   options
 ) {
+  assert(
+    'Must provide a DOM element when using removeEventListener',
+    !!element
+  );
+  assert(
+    'Must provide an element (not a DOM selector) when using removeEventListener.',
+    element instanceof Element
+  );
+
   let listeners = getEventListeners(obj);
 
   if (listeners.length === 0) {

--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { run } from '@ember/runloop';
-import { assert } from '@ember/debug';
 import { registerDisposable } from './utils/disposable';
 
 const { WeakMap } = Ember;
@@ -84,31 +83,7 @@ const INDEX = {
    @param { Function } _callback the callback to run for that event
    @public
    */
-export function addEventListener(obj, selector, eventName, _callback, options) {
-  assert(
-    'Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
-    !obj.isComponent || obj.tagName !== '' || typeof selector !== 'string'
-  );
-  assert(
-    'Called addEventListener with a css selector before the component was rendered',
-    !obj.isComponent ||
-      typeof selector !== 'string' ||
-      obj._currentState === obj._states.inDOM
-  );
-  assert(
-    'Must provide an element (not a DOM selector) when calling addEventListener outside of component instance.',
-    obj.isComponent || typeof selector !== 'string'
-  );
-
-  // If no element is provided, we assume we're adding the event listener to the component's element. This
-  // addresses use cases where we want to bind events like `scroll` to the component's root element.
-  if (obj.isComponent && typeof eventName === 'function') {
-    _callback = eventName;
-    eventName = selector;
-    selector = obj.element;
-  }
-
-  let element = findElement(obj.element, selector);
+export function addEventListener(obj, element, eventName, _callback, options) {
   let callback = run.bind(obj, _callback);
 
   let listeners = getEventListeners(obj);
@@ -130,17 +105,11 @@ export function addEventListener(obj, selector, eventName, _callback, options) {
    */
 export function removeEventListener(
   obj,
-  selector,
+  element,
   eventName,
   callback,
   options
 ) {
-  assert(
-    'Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
-    obj.tagName !== '' || typeof selector !== 'string'
-  );
-
-  let element = findElement(obj.element, selector);
   let listeners = getEventListeners(obj);
 
   if (listeners.length === 0) {
@@ -196,22 +165,4 @@ function getEventListeners(obj) {
   }
 
   return listeners;
-}
-
-function findElement(contextElement, selector) {
-  let selectorType = typeof selector;
-  let element;
-
-  if (selectorType === 'string') {
-    element = contextElement.querySelector(selector);
-  } else if (selector.nodeType || selector === window) {
-    element = selector;
-  }
-
-  assert(
-    `Called addEventListener with selector not found in DOM: ${selector}`,
-    !!element
-  );
-
-  return element;
 }

--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -152,19 +152,19 @@ function assertArguments(element, eventName, callback) {
   assert('Must provide a callback to run for the given event name', !!callback);
 }
 
-function getEventListenersDisposable(eventListeners) {
+function getEventListenersDisposable(listeners) {
   return function() {
-    if (eventListeners !== undefined) {
+    if (listeners !== undefined) {
       /* Drop non-passive event listeners */
-      for (let i = 0; i < eventListeners.length; i += LISTENER_ITEM_LENGTH) {
-        let element = eventListeners[i + INDEX.ELEMENT];
-        let eventName = eventListeners[i + INDEX.EVENT_NAME];
-        let callback = eventListeners[i + INDEX.CALLBACK];
-        let options = eventListeners[i + INDEX.OPTIONS];
+      for (let i = 0; i < listeners.length; i += LISTENER_ITEM_LENGTH) {
+        let element = listeners[i + INDEX.ELEMENT];
+        let eventName = listeners[i + INDEX.EVENT_NAME];
+        let callback = listeners[i + INDEX.CALLBACK];
+        let options = listeners[i + INDEX.OPTIONS];
 
         element.removeEventListener(eventName, callback, options);
       }
-      eventListeners.length = 0;
+      listeners.length = 0;
     }
   };
 }

--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -80,32 +80,28 @@ const INDEX = {
    @method addEventListener
    @param { Object } obj the instance to attach the listener for
    @param { String } selector the DOM selector or element
-   @param { String } _eventName the event name to listen for
-   @param { Function } _callback the callback to run for that event
+   @param { String } eventName the event name to listen for
+   @param { Function } callback the callback to run for that event
    @public
    */
-export function addEventListener(obj, element, eventName, _callback, options) {
-  assert('Must provide a DOM element when using addEventListener', !!element);
-  assert(
-    'Must provide an element (not a DOM selector) when using addEventListener.',
-    element instanceof Element
-  );
+export function addEventListener(obj, element, eventName, callback, options) {
+  assertArguments(element, eventName, callback);
 
-  let callback = run.bind(obj, _callback);
+  let _callback = run.bind(obj, callback);
   let listeners = getEventListeners(obj);
 
   if (!PASSIVE_SUPPORTED) {
     options = undefined;
   }
 
-  element.addEventListener(eventName, callback, options);
-  listeners.push(element, eventName, callback, _callback, options);
+  element.addEventListener(eventName, _callback, options);
+  listeners.push(element, eventName, _callback, callback, options);
 }
 
 /**
    @param { Object } obj the instance to remove the listener for
    @param { String } selector the DOM selector or element
-   @param { String } _eventName the event name to listen for
+   @param { String } eventName the event name to listen for
    @param { Function } callback the callback to run for that event
    @public
    */
@@ -116,14 +112,7 @@ export function removeEventListener(
   callback,
   options
 ) {
-  assert(
-    'Must provide a DOM element when using removeEventListener',
-    !!element
-  );
-  assert(
-    'Must provide an element (not a DOM selector) when using removeEventListener.',
-    element instanceof Element
-  );
+  assertArguments(element, eventName, callback);
 
   let listeners = getEventListeners(obj);
 
@@ -153,6 +142,16 @@ export function removeEventListener(
   }
 }
 
+function assertArguments(element, eventName, callback) {
+  assert('Must provide a DOM element', !!element);
+  assert('Must provide an element (not a DOM selector)', !!element.nodeType);
+  assert(
+    'Must provide an eventName that specifies the event type',
+    !!eventName
+  );
+  assert('Must provide a callback to run for the given event name', !!callback);
+}
+
 function getEventListenersDisposable(eventListeners) {
   return function() {
     if (eventListeners !== undefined) {
@@ -173,7 +172,7 @@ function getEventListenersDisposable(eventListeners) {
 function getEventListeners(obj) {
   let listeners = eventListeners.get(obj);
 
-  if (!listeners) {
+  if (listeners === undefined) {
     listeners = [];
     eventListeners.set(obj, listeners);
     registerDisposable(obj, getEventListenersDisposable(listeners));

--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -1,0 +1,202 @@
+import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { assert } from '@ember/debug';
+import { registerDisposable } from './utils/disposable';
+
+const { WeakMap } = Ember;
+
+const eventListeners = new WeakMap();
+
+const PASSIVE_SUPPORTED = (() => {
+  let ret = false;
+
+  try {
+    let options = Object.defineProperty({}, 'passive', {
+      get() {
+        ret = true;
+      },
+    });
+
+    window.addEventListener('test', null, options);
+  } catch (err) {
+    // intentionally empty
+  }
+  return ret;
+})();
+
+const LISTENER_ITEM_LENGTH = 5;
+const INDEX = {
+  ELEMENT: 0,
+  EVENT_NAME: 1,
+  CALLBACK: 2,
+  ORIGINAL_CALLBACK: 3,
+  OPTIONS: 4,
+};
+
+/**
+   Attaches an event listener that will automatically be removed when the host
+   object is dropped from DOM.
+
+   Example:
+
+   ```js
+   import Component from 'ember-component';
+   import { addEventListener } from 'ember-lifeline';
+
+   export default Component.extend({
+     didInsertElement() {
+       addEventListener(this, '.some-item', 'click', (e) => {
+         console.log('.some-item was clicked');
+       });
+     }
+   });
+   ```
+
+   This can also be used in other ember types like services and controllers. In
+   order to use it there an html element reference must be used instead of a
+   css selector. This way we can be sure the element actually exists when the
+   listener is attached:
+
+   ```js
+   import Service from 'ember-service';
+   import { addEventListener } from 'ember-lifeline';
+
+   export default Service.extend({
+     init() {
+       this._super(...arguments);
+       const el = document.querySelector('.foo');
+       addEventListener(this, el, 'click')
+     }
+   });
+   ```
+
+   @method addEventListener
+   @param { Object } obj the instance to attach the listener for
+   @param { String } selector the DOM selector or element
+   @param { String } _eventName the event name to listen for
+   @param { Function } _callback the callback to run for that event
+   @public
+   */
+export function addEventListener(obj, selector, eventName, _callback, options) {
+  assert(
+    'Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
+    !obj.isComponent || obj.tagName !== '' || typeof selector !== 'string'
+  );
+  assert(
+    'Called addEventListener with a css selector before the component was rendered',
+    !obj.isComponent ||
+      typeof selector !== 'string' ||
+      obj._currentState === obj._states.inDOM
+  );
+  assert(
+    'Must provide an element (not a DOM selector) when calling addEventListener outside of component instance.',
+    obj.isComponent || typeof selector !== 'string'
+  );
+
+  let element = findElement(obj.element, selector);
+  let callback = run.bind(obj, _callback);
+
+  let listeners = getEventListeners(obj);
+
+  if (!PASSIVE_SUPPORTED) {
+    options = undefined;
+  }
+
+  element.addEventListener(eventName, callback, options);
+  listeners.push(element, eventName, callback, _callback, options);
+}
+
+/**
+   @param { Object } obj the instance to remove the listener for
+   @param { String } selector the DOM selector or element
+   @param { String } _eventName the event name to listen for
+   @param { Function } callback the callback to run for that event
+   @public
+   */
+export function removeEventListener(
+  obj,
+  selector,
+  eventName,
+  callback,
+  options
+) {
+  assert(
+    'Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
+    obj.tagName !== '' || typeof selector !== 'string'
+  );
+
+  let element = findElement(obj.element, selector);
+  let listeners = getEventListeners(obj);
+
+  if (listeners.length === 0) {
+    return;
+  }
+
+  if (!PASSIVE_SUPPORTED) {
+    options = undefined;
+  }
+
+  // We cannot use Array.findIndex as we cannot rely on babel/polyfill being present
+  for (let i = 0; i < listeners.length; i += LISTENER_ITEM_LENGTH) {
+    if (
+      listeners[i + INDEX.ELEMENT] === element &&
+      listeners[i + INDEX.EVENT_NAME] === eventName &&
+      listeners[i + INDEX.ORIGINAL_CALLBACK] === callback
+    ) {
+      /*
+         * Drop the event listener and remove the listener object
+         */
+      let ownCallback = listeners[i + INDEX.CALLBACK];
+      element.removeEventListener(eventName, ownCallback, options);
+      listeners.splice(i, LISTENER_ITEM_LENGTH);
+      break;
+    }
+  }
+}
+
+function getEventListenersDisposable(eventListeners) {
+  return function() {
+    if (eventListeners !== undefined) {
+      /* Drop non-passive event listeners */
+      for (let i = 0; i < eventListeners.length; i += LISTENER_ITEM_LENGTH) {
+        let element = eventListeners[i + INDEX.ELEMENT];
+        let eventName = eventListeners[i + INDEX.EVENT_NAME];
+        let callback = eventListeners[i + INDEX.CALLBACK];
+        let options = eventListeners[i + INDEX.OPTIONS];
+
+        element.removeEventListener(eventName, callback, options);
+      }
+      eventListeners = undefined;
+    }
+  };
+}
+
+function getEventListeners(obj) {
+  let listeners = eventListeners.get(obj);
+
+  if (!listeners) {
+    listeners = [];
+    eventListeners.set(obj, listeners);
+    registerDisposable(obj, getEventListenersDisposable(listeners));
+  }
+
+  return listeners;
+}
+
+function findElement(contextElement, selector) {
+  let selectorType = typeof selector;
+  let element;
+
+  if (selectorType === 'string') {
+    element = contextElement.querySelector(selector);
+  } else if (selector.nodeType || selector === window) {
+    element = selector;
+  }
+
+  assert(
+    `Called addEventListener with selector not found in DOM: ${selector}`,
+    !!element
+  );
+
+  return element;
+}

--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -164,7 +164,7 @@ function getEventListenersDisposable(eventListeners) {
 
         element.removeEventListener(eventName, callback, options);
       }
-      eventListeners = undefined;
+      eventListeners.length = 0;
     }
   };
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,9 @@
 export { runTask, scheduleTask, throttleTask, cancelTask } from './run-task';
 export { pollTask, pollTaskFor, setShouldPoll, cancelPoll } from './poll-task';
 export { debounceTask, cancelDebounce } from './debounce-task';
+export { addEventListener, removeEventListener } from './dom-event-listeners';
 export { runDisposables } from './utils/disposable';
+
 export { ContextBoundTasksMixin } from './mixins/run';
 export { ContextBoundEventListenersMixin } from './mixins/dom';
 export { DisposableMixin } from './mixins/disposable';

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -1,32 +1,6 @@
 import Mixin from '@ember/object/mixin';
-import { run } from '@ember/runloop';
-import { assert } from '@ember/debug';
-
-const PASSIVE_SUPPORTED = (() => {
-  let ret = false;
-
-  try {
-    let options = Object.defineProperty({}, 'passive', {
-      get() {
-        ret = true;
-      },
-    });
-
-    window.addEventListener('test', null, options);
-  } catch (err) {
-    // intentionally empty
-  }
-  return ret;
-})();
-
-const LISTENER_ITEM_LENGTH = 5;
-const INDEX = {
-  ELEMENT: 0,
-  EVENT_NAME: 1,
-  CALLBACK: 2,
-  ORIGINAL_CALLBACK: 3,
-  OPTIONS: 4,
-};
+import { addEventListener, removeEventListener } from '../dom-event-listeners';
+import { runDisposables } from '../utils/disposable';
 
 /**
  ContextBoundEventListenersMixin provides a mechanism to attach event listeners
@@ -39,11 +13,6 @@ const INDEX = {
  @public
  */
 export default Mixin.create({
-  init() {
-    this._super(...arguments);
-
-    this._listeners = undefined;
-  },
   /**
    Attaches an event listener that will automatically be removed when the host
    object is dropped from DOM.
@@ -88,108 +57,22 @@ export default Mixin.create({
    @public
    */
   addEventListener(selector, eventName, _callback, options) {
-    assert(
-      'Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
-      !this.isComponent || this.tagName !== '' || typeof selector !== 'string'
-    );
-    assert(
-      'Called addEventListener with a css selector before the component was rendered',
-      !this.isComponent ||
-        typeof selector !== 'string' ||
-        this._currentState === this._states.inDOM
-    );
-    assert(
-      'Must provide an element (not a DOM selector) when calling addEventListener outside of component instance.',
-      this.isComponent || typeof selector !== 'string'
-    );
-
-    let element = findElement(this.element, selector);
-    let callback = run.bind(this, _callback);
-
-    if (this._listeners === undefined) {
-      this._listeners = [];
-    }
-
-    if (!PASSIVE_SUPPORTED) {
-      options = undefined;
-    }
-
-    element.addEventListener(eventName, callback, options);
-    this._listeners.push(element, eventName, callback, _callback, options);
+    addEventListener(this, selector, eventName, _callback, options);
   },
 
   /**
-
    @param { String } selector the DOM selector or element
    @param { String } _eventName the event name to listen for
    @param { Function } callback the callback to run for that event
    @public
    */
   removeEventListener(selector, eventName, callback, options) {
-    assert(
-      'Must provide an element (not a DOM selector) when using addEventListener in a tagless component.',
-      this.tagName !== '' || typeof selector !== 'string'
-    );
-
-    let element = findElement(this.element, selector);
-
-    if (this._listeners === undefined) {
-      return;
-    }
-
-    if (!PASSIVE_SUPPORTED) {
-      options = undefined;
-    }
-
-    // We cannot use Array.findIndex as we cannot rely on babel/polyfill being present
-    for (let i = 0; i < this._listeners.length; i += LISTENER_ITEM_LENGTH) {
-      if (
-        this._listeners[i + INDEX.ELEMENT] === element &&
-        this._listeners[i + INDEX.EVENT_NAME] === eventName &&
-        this._listeners[i + INDEX.ORIGINAL_CALLBACK] === callback
-      ) {
-        /*
-         * Drop the event listener and remove the listener object
-         */
-        let ownCallback = this._listeners[i + INDEX.CALLBACK];
-        element.removeEventListener(eventName, ownCallback, options);
-        this._listeners.splice(i, LISTENER_ITEM_LENGTH);
-        break;
-      }
-    }
+    removeEventListener(this, selector, eventName, callback, options);
   },
 
   destroy() {
     this._super(...arguments);
-    if (this._listeners !== undefined) {
-      /* Drop non-passive event listeners */
-      for (let i = 0; i < this._listeners.length; i += LISTENER_ITEM_LENGTH) {
-        let element = this._listeners[i + INDEX.ELEMENT];
-        let eventName = this._listeners[i + INDEX.EVENT_NAME];
-        let callback = this._listeners[i + INDEX.CALLBACK];
-        let options = this._listeners[i + INDEX.OPTIONS];
 
-        element.removeEventListener(eventName, callback, options);
-      }
-      this._listeners = undefined;
-    }
+    runDisposables(this);
   },
 });
-
-function findElement(contextElement, selector) {
-  let selectorType = typeof selector;
-  let element;
-
-  if (selectorType === 'string') {
-    element = contextElement.querySelector(selector);
-  } else if (selector.nodeType || selector === window) {
-    element = selector;
-  }
-
-  assert(
-    `Called addEventListener with selector not found in DOM: ${selector}`,
-    !!element
-  );
-
-  return element;
-}

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -75,6 +75,7 @@ export default Mixin.create({
     // If no element is provided, we assume we're adding the event listener to the component's element. This
     // addresses use cases where we want to bind events like `scroll` to the component's root element.
     if (this.isComponent && typeof eventName === 'function') {
+      options = callback;
       callback = eventName;
       eventName = selector;
       element = this.element;

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -108,9 +108,9 @@ export default Mixin.create({
   },
 
   destroy() {
-    this._super(...arguments);
-
     runDisposables(this);
+
+    this._super(...arguments);
   },
 });
 

--- a/addon/mixins/dom.js
+++ b/addon/mixins/dom.js
@@ -6,9 +6,6 @@ import { runDisposables } from '../utils/disposable';
  ContextBoundEventListenersMixin provides a mechanism to attach event listeners
  with runloops and automatic removal when the host object is removed from DOM.
 
- These capabilities are very commonly needed, so this mixin is by default
- included into all `Ember.View` and `Ember.Component` instances.
-
  @class ContextBoundEventListenersMixin
  @public
  */

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -334,8 +334,8 @@ export default Mixin.create({
   },
 
   destroy() {
-    this._super(...arguments);
-
     runDisposables(this);
+
+    this._super(...arguments);
   },
 });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-helpers": "0.5.2",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.14.0-beta.1",
+    "ember-source": "~2.18.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-prettier": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^4.0.0",
+    "ember-cli-qunit": "^4.3.2",
     "ember-cli-release": "^0.2.9",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
   }
 
   if (environment === 'production') {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import resolver from './helpers/resolver';
 import QUnit from 'qunit';
-import { setResolver } from 'ember-qunit';
+import { setResolver } from '@ember/test-helpers';
 import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -12,18 +12,14 @@ const TESTS_WITH_LEAKY_ASYNC = [];
 const { run } = Ember;
 
 QUnit.testStart(() => {
-  performance.mark('test-start');
   Ember.testing = true;
 });
 
 QUnit.testDone(({ module, name }) => {
-  performance.mark('test-end');
   if (run.hasScheduledTimers()) {
     TESTS_WITH_LEAKY_ASYNC.push(`${module}: ${name}`);
     run.cancelTimers();
   }
-
-  performance.measure('test', 'test-start', 'test-end');
 
   Ember.testing = false;
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,24 +1,29 @@
 import Ember from 'ember';
-import resolver from './helpers/resolver';
 import QUnit from 'qunit';
-import { setResolver } from '@ember/test-helpers';
+import Application from '../app';
+import config from '../config/environment';
+import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-cli-qunit';
 
-setResolver(resolver);
+setApplication(Application.create(config.APP));
 start();
 
 const TESTS_WITH_LEAKY_ASYNC = [];
 const { run } = Ember;
 
 QUnit.testStart(() => {
+  performance.mark('test-start');
   Ember.testing = true;
 });
 
 QUnit.testDone(({ module, name }) => {
+  performance.mark('test-end');
   if (run.hasScheduledTimers()) {
     TESTS_WITH_LEAKY_ASYNC.push(`${module}: ${name}`);
     run.cancelTimers();
   }
+
+  performance.measure('test', 'test-start', 'test-end');
 
   Ember.testing = false;
 });

--- a/tests/unit/debounce-task-test.js
+++ b/tests/unit/debounce-task-test.js
@@ -6,12 +6,12 @@ module('ember-lifeline/debounce-task', function(hooks) {
   hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend();
 
-    this.subject = function() {
-      if (this._subject) {
-        return this._subject;
+    this.getComponent = function() {
+      if (this._component) {
+        return this._component;
       }
 
-      return (this._subject = this.BaseObject.create(...arguments));
+      return (this._component = this.BaseObject.create(...arguments));
     };
   });
 
@@ -25,7 +25,7 @@ module('ember-lifeline/debounce-task', function(hooks) {
     let done = assert.async();
     let runCount = 0;
     let runArg;
-    let obj = (this.obj = this.subject({
+    let obj = (this.obj = this.getComponent({
       doStuff(arg) {
         runCount++;
         assert.equal(this, obj, 'context is correct');
@@ -51,7 +51,7 @@ module('ember-lifeline/debounce-task', function(hooks) {
     assert.expect(2);
 
     let runCount = 0;
-    this.obj = this.subject({
+    this.obj = this.getComponent({
       doStuff() {
         runCount++;
       },

--- a/tests/unit/debounce-task-test.js
+++ b/tests/unit/debounce-task-test.js
@@ -2,70 +2,70 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { debounceTask, cancelDebounce, runDisposables } from 'ember-lifeline';
 
-module('ember-lifeline/debounce-task', {
-  beforeEach() {
+module('ember-lifeline/debounce-task', function(hooks) {
+  hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend();
-  },
 
-  afterEach() {
-    runDisposables(this.obj);
-  },
+    this.subject = function() {
+      if (this._subject) {
+        return this._subject;
+      }
 
-  subject() {
-    if (this._subject) {
-      return this._subject;
-    }
-
-    return (this._subject = this.BaseObject.create(...arguments));
-  },
-});
-
-test('debounceTask runs tasks', function(assert) {
-  assert.expect(4);
-
-  let done = assert.async();
-  let runCount = 0;
-  let runArg;
-  let obj = (this.obj = this.subject({
-    doStuff(arg) {
-      runCount++;
-      assert.equal(this, obj, 'context is correct');
-      runArg = arg;
-    },
-  }));
-
-  debounceTask(this.obj, 'doStuff', 'arg1', 5);
-  debounceTask(this.obj, 'doStuff', 'arg2', 5);
-  debounceTask(this.obj, 'doStuff', 'arg3', 5);
-
-  assert.equal(runCount, 0, 'should not have run');
-
-  window.setTimeout(() => {
-    assert.equal(runCount, 1, 'should have run only once');
-    assert.equal(runArg, 'arg3', 'should run the task with the last arg');
-    done();
-  }, 10);
-});
-
-test('debounceTask can be canceled', function(assert) {
-  let done = assert.async();
-  assert.expect(2);
-
-  let runCount = 0;
-  this.obj = this.subject({
-    doStuff() {
-      runCount++;
-    },
+      return (this._subject = this.BaseObject.create(...arguments));
+    };
   });
 
-  debounceTask(this.obj, 'doStuff', 5);
-  debounceTask(this.obj, 'doStuff', 5);
-  cancelDebounce(this.obj, 'doStuff');
+  hooks.afterEach(function() {
+    runDisposables(this.obj);
+  });
 
-  assert.equal(runCount, 0, 'should not have run');
+  test('debounceTask runs tasks', function(assert) {
+    assert.expect(4);
 
-  window.setTimeout(() => {
+    let done = assert.async();
+    let runCount = 0;
+    let runArg;
+    let obj = (this.obj = this.subject({
+      doStuff(arg) {
+        runCount++;
+        assert.equal(this, obj, 'context is correct');
+        runArg = arg;
+      },
+    }));
+
+    debounceTask(this.obj, 'doStuff', 'arg1', 5);
+    debounceTask(this.obj, 'doStuff', 'arg2', 5);
+    debounceTask(this.obj, 'doStuff', 'arg3', 5);
+
     assert.equal(runCount, 0, 'should not have run');
-    done();
-  }, 10);
+
+    window.setTimeout(() => {
+      assert.equal(runCount, 1, 'should have run only once');
+      assert.equal(runArg, 'arg3', 'should run the task with the last arg');
+      done();
+    }, 10);
+  });
+
+  test('debounceTask can be canceled', function(assert) {
+    let done = assert.async();
+    assert.expect(2);
+
+    let runCount = 0;
+    this.obj = this.subject({
+      doStuff() {
+        runCount++;
+      },
+    });
+
+    debounceTask(this.obj, 'doStuff', 5);
+    debounceTask(this.obj, 'doStuff', 5);
+    cancelDebounce(this.obj, 'doStuff');
+
+    assert.equal(runCount, 0, 'should not have run');
+
+    window.setTimeout(() => {
+      assert.equal(runCount, 0, 'should not have run');
+      done();
+    }, 10);
+  });
 });

--- a/tests/unit/dom-event-listeners-test.js
+++ b/tests/unit/dom-event-listeners-test.js
@@ -176,15 +176,39 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
       assert.equal(ranCallback, 1, 'callback was not called a second time');
     });
 
-    test(`${testName} throws when there is no element to attach to`, async function(assert) {
-      assert.expect(1);
+    test(`${testName} throws when called with incorrect arguments`, async function(assert) {
+      assert.expect(4);
 
       await render(hbs`{{under-test}}`);
       let component = this.componentInstance;
 
       assert.throws(() => {
         addEventListener(component, null, 'click', () => {}, testedOptions);
-      }, /Must provide a DOM element when using addEventListener/);
+      }, /Must provide a DOM element/);
+
+      assert.throws(() => {
+        addEventListener(component, {}, 'click', () => {}, testedOptions);
+      }, /Must provide an element \(not a DOM selector\)/);
+
+      assert.throws(() => {
+        addEventListener(
+          component,
+          component.element,
+          null,
+          () => {},
+          testedOptions
+        );
+      }, /Must provide an eventName that specifies the event type/);
+
+      assert.throws(() => {
+        addEventListener(
+          component,
+          component.element,
+          'click',
+          null,
+          testedOptions
+        );
+      }, /Must provide a callback to run for the given event name/);
     });
 
     test(`${testName} listeners on different contexts can be torn down without impacting other contexts`, async function(assert) {

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -41,14 +41,14 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       testedOptions: { passive: false },
     },
   ].forEach(({ testName, testedOptions }) => {
-    test(`${testName} adds event listener to child element`, function(assert) {
+    test(`${testName} adds event listener to child element`, async function(assert) {
       assert.expect(4);
 
       this.owner.register(
         'template:components/under-test',
         hbs`<span class="foo"></span>`
       );
-      render(hbs`{{under-test}}`);
+      await render(hbs`{{under-test}}`);
       let subject = this.componentInstance;
 
       let calls = 0;
@@ -78,14 +78,14 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       );
     });
 
-    test(`${testName} adds event listener to component's element when not providing element`, function(assert) {
+    test(`${testName} adds event listener to component's element when not providing element`, async function(assert) {
       assert.expect(4);
 
       this.owner.register(
         'template:components/under-test',
         hbs`<span class="foo"></span>`
       );
-      render(hbs`{{under-test}}`);
+      await render(hbs`{{under-test}}`);
       let subject = this.componentInstance;
 
       let calls = 0;
@@ -121,7 +121,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         'template:components/under-test',
         hbs`<span class="foo"></span>`
       );
-      render(hbs`{{under-test}}`);
+      await render(hbs`{{under-test}}`);
       let subject = this.componentInstance;
 
       let calls = 0;
@@ -158,7 +158,9 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.expect(5);
 
       this.set('show', true);
-      render(hbs`{{#if show}}{{under-test}}{{/if}}<span class="foo"></span>`);
+      await render(
+        hbs`{{#if show}}{{under-test}}{{/if}}<span class="foo"></span>`
+      );
       let subject = this.componentInstance;
 
       let ranCallback = 0;
@@ -197,10 +199,10 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.equal(ranCallback, 1, 'callback was not called a second time');
     });
 
-    test(`${testName} throws when there is no element to attach to`, function(assert) {
+    test(`${testName} throws when there is no element to attach to`, async function(assert) {
       assert.expect(1);
 
-      render(hbs`{{under-test}}`);
+      await render(hbs`{{under-test}}`);
       let subject = this.componentInstance;
 
       assert.throws(() => {
@@ -222,7 +224,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.expect(5);
 
       this.set('show', true);
-      render(
+      await render(
         hbs`{{#if show}}{{under-test tagName=""}}{{/if}}<span class="foo"></span>`
       );
       let subject = this.componentInstance;
@@ -262,10 +264,10 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.equal(calls, 1, 'callback was not called again');
     });
 
-    test(`${testName} throws when using a string selector in a tagless component`, function(assert) {
+    test(`${testName} throws when using a string selector in a tagless component`, async function(assert) {
       assert.expect(1);
 
-      render(hbs`{{under-test tagName=""}}<span class="foo"></span>`);
+      await render(hbs`{{under-test tagName=""}}<span class="foo"></span>`);
       let subject = this.componentInstance;
 
       assert.throws(() => {
@@ -273,7 +275,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       }, /Must provide an element/);
     });
 
-    test(`${testName} listeners on different contexts can be torn down without impacting other contexts`, function(assert) {
+    test(`${testName} listeners on different contexts can be torn down without impacting other contexts`, async function(assert) {
       assert.expect(2);
 
       let testContext = this;
@@ -297,7 +299,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       );
 
       this.set('showA', true);
-      render(
+      await render(
         hbs`{{#if showA}}{{under-test-a}}{{/if}}{{under-test-b}}<span class="foo"></span>`
       );
 
@@ -321,7 +323,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.equal(calls, 3, 'one more callback called for remaining context');
     });
 
-    test(`${testName} listeners are called with correct scope`, function(assert) {
+    test(`${testName} listeners are called with correct scope`, async function(assert) {
       assert.expect(2);
 
       let testContext = this;
@@ -345,7 +347,9 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         })
       );
 
-      render(hbs`{{under-test-a}}{{under-test-b}}<span class="foo"></span>`);
+      await render(
+        hbs`{{under-test-a}}{{under-test-b}}<span class="foo"></span>`
+      );
 
       let { subjectA, subjectB } = this;
       let target = find('.foo');
@@ -381,7 +385,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         'template:components/under-test',
         hbs`<span class="foo"></span>`
       );
-      render(hbs`{{under-test}}`);
+      await render(hbs`{{under-test}}`);
       let subject = this.componentInstance;
       let calls = 0;
       let listener = () => {
@@ -412,7 +416,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         : this.owner._lookupFactory(serviceName);
       let subject = factory.create();
 
-      render(hbs`<span class="foo"></span>`);
+      await render(hbs`<span class="foo"></span>`);
 
       let calls = 0;
       let hadRunloop = null;

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -1,21 +1,21 @@
 /* global Event */
 import { run } from '@ember/runloop';
-import { getOwner } from '@ember/application';
 import Component from '@ember/component';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
 import { find, triggerEvent } from 'ember-native-dom-helpers';
 
-moduleForComponent('ember-lifeline/mixins/dom', {
-  integration: true,
+module('ember-lifeline/mixins/dom', function(hooks) {
+  setupRenderingTest(hooks);
 
-  beforeEach() {
+  hooks.beforeEach(function() {
     let testContext = this;
     let name = 'component:under-test';
 
-    this.owner = getOwner(this);
     this.owner.register(
       name,
       Component.extend(ContextBoundEventListenersMixin, {
@@ -29,507 +29,503 @@ moduleForComponent('ember-lifeline/mixins/dom', {
     this.Component = this.owner.factoryFor
       ? this.owner.factoryFor(name)
       : this.owner._lookupFactory(name);
-  },
-});
-
-[
-  {
-    testName: 'addEventListener(_,_,_,undefined)',
-    testedOptions: undefined,
-  },
-  {
-    testName: 'addEventListener(_,_,_,{passive:false})',
-    testedOptions: { passive: false },
-  },
-].forEach(({ testName, testedOptions }) => {
-  test(`${testName} adds event listener to child element`, function(assert) {
-    assert.expect(4);
-
-    this.register(
-      'template:components/under-test',
-      hbs`<span class="foo"></span>`
-    );
-    this.render(hbs`{{under-test}}`);
-    let subject = this.componentInstance;
-
-    let calls = 0;
-    let hadRunloop = null;
-    let handledEvent = null;
-
-    subject.addEventListener(
-      '.foo',
-      'click',
-      event => {
-        calls++;
-        hadRunloop = !!run.currentRunLoop;
-        handledEvent = event;
-      },
-      testedOptions
-    );
-
-    subject.element.firstChild.dispatchEvent(new Event('click'));
-
-    assert.equal(calls, 1, 'callback was called');
-    assert.ok(hadRunloop, 'callback was called in runloop');
-    assert.ok(handledEvent.target, 'callback passed a target');
-    assert.equal(
-      handledEvent.target.className,
-      'foo',
-      'target has the expected class'
-    );
   });
 
-  test(`${testName} adds event listener to component's element when not providing element`, function(assert) {
-    assert.expect(4);
+  [
+    {
+      testName: 'addEventListener(_,_,_,undefined)',
+      testedOptions: undefined,
+    },
+    {
+      testName: 'addEventListener(_,_,_,{passive:false})',
+      testedOptions: { passive: false },
+    },
+  ].forEach(({ testName, testedOptions }) => {
+    test(`${testName} adds event listener to child element`, function(assert) {
+      assert.expect(4);
 
-    this.register(
-      'template:components/under-test',
-      hbs`<span class="foo"></span>`
-    );
-    this.render(hbs`{{under-test}}`);
-    let subject = this.componentInstance;
+      this.owner.register(
+        'template:components/under-test',
+        hbs`<span class="foo"></span>`
+      );
+      render(hbs`{{under-test}}`);
+      let subject = this.componentInstance;
 
-    let calls = 0;
-    let hadRunloop = null;
-    let handledEvent = null;
+      let calls = 0;
+      let hadRunloop = null;
+      let handledEvent = null;
 
-    subject.addEventListener(
-      'click',
-      event => {
-        calls++;
-        hadRunloop = !!run.currentRunLoop;
-        handledEvent = event;
-      },
-      testedOptions
-    );
+      subject.addEventListener(
+        '.foo',
+        'click',
+        event => {
+          calls++;
+          hadRunloop = !!run.currentRunLoop;
+          handledEvent = event;
+        },
+        testedOptions
+      );
 
-    subject.element.dispatchEvent(new Event('click'));
+      subject.element.firstChild.dispatchEvent(new Event('click'));
 
-    assert.equal(calls, 1, 'callback was called');
-    assert.ok(hadRunloop, 'callback was called in runloop');
-    assert.ok(handledEvent.target, 'callback passed a target');
-    assert.equal(
-      handledEvent.target.className,
-      'ember-view',
-      'target has the expected class'
-    );
-  });
-
-  test(`${testName} adds event listener to child element with multiple handler args`, async function(assert) {
-    assert.expect(4);
-
-    this.register(
-      'template:components/under-test',
-      hbs`<span class="foo"></span>`
-    );
-    this.render(hbs`{{under-test}}`);
-    let subject = this.componentInstance;
-
-    let calls = 0;
-    let hadRunloop = null;
-    let handledArgs = null;
-
-    subject.addEventListener(
-      '.foo',
-      'drag',
-      (...args) => {
-        calls++;
-        hadRunloop = !!run.currentRunLoop;
-        handledArgs = args[0];
-      },
-      testedOptions
-    );
-
-    let delta = {};
-    await triggerEvent(subject.element.firstChild, 'drag', {
-      details: { delta },
+      assert.equal(calls, 1, 'callback was called');
+      assert.ok(hadRunloop, 'callback was called in runloop');
+      assert.ok(handledEvent.target, 'callback passed a target');
+      assert.equal(
+        handledEvent.target.className,
+        'foo',
+        'target has the expected class'
+      );
     });
 
-    assert.equal(calls, 1, 'callback was called');
-    assert.ok(hadRunloop, 'callback was called in runloop');
-    assert.ok(handledArgs.target, 'callback passed a target');
-    assert.equal(
-      handledArgs.details.delta,
-      delta,
-      'second argument can be present'
-    );
-  });
+    test(`${testName} adds event listener to component's element when not providing element`, function(assert) {
+      assert.expect(4);
 
-  test(`${testName} adds event listener to non-child element`, async function(assert) {
-    assert.expect(5);
+      this.owner.register(
+        'template:components/under-test',
+        hbs`<span class="foo"></span>`
+      );
+      render(hbs`{{under-test}}`);
+      let subject = this.componentInstance;
 
-    this.set('show', true);
-    this.render(
-      hbs`{{#if show}}{{under-test}}{{/if}}<span class="foo"></span>`
-    );
-    let subject = this.componentInstance;
+      let calls = 0;
+      let hadRunloop = null;
+      let handledEvent = null;
 
-    let ranCallback = 0;
-    let hadRunloop = null;
-    let handledEvent = null;
-    let element = find('.foo');
+      subject.addEventListener(
+        'click',
+        event => {
+          calls++;
+          hadRunloop = !!run.currentRunLoop;
+          handledEvent = event;
+        },
+        testedOptions
+      );
 
-    subject.addEventListener(
-      element,
-      'click',
-      event => {
-        ranCallback++;
-        hadRunloop = !!run.currentRunLoop;
-        handledEvent = event;
-      },
-      testedOptions
-    );
+      subject.element.dispatchEvent(new Event('click'));
 
-    await triggerEvent(element, 'click');
+      assert.equal(calls, 1, 'callback was called');
+      assert.ok(hadRunloop, 'callback was called in runloop');
+      assert.ok(handledEvent.target, 'callback passed a target');
+      assert.equal(
+        handledEvent.target.className,
+        'ember-view',
+        'target has the expected class'
+      );
+    });
 
-    assert.equal(ranCallback, 1, 'callback was called once');
-    assert.ok(hadRunloop, 'callback was called in runloop');
-    assert.ok(!!handledEvent.target, 'callback passed a target');
-    assert.equal(
-      handledEvent.target.className,
-      'foo',
-      'target has the expected class'
-    );
+    test(`${testName} adds event listener to child element with multiple handler args`, async function(assert) {
+      assert.expect(4);
 
-    this.set('show', false);
+      this.owner.register(
+        'template:components/under-test',
+        hbs`<span class="foo"></span>`
+      );
+      render(hbs`{{under-test}}`);
+      let subject = this.componentInstance;
 
-    // Trigger the event on the non-child element again, after the component
-    // is removed from DOM. The listener should not fire this time.
-    await triggerEvent(element, 'click');
+      let calls = 0;
+      let hadRunloop = null;
+      let handledArgs = null;
 
-    assert.equal(ranCallback, 1, 'callback was not called a second time');
-  });
+      subject.addEventListener(
+        '.foo',
+        'drag',
+        (...args) => {
+          calls++;
+          hadRunloop = !!run.currentRunLoop;
+          handledArgs = args[0];
+        },
+        testedOptions
+      );
 
-  test(`${testName} throws when there is no element to attach to`, function(assert) {
-    assert.expect(1);
+      let delta = {};
+      await triggerEvent(subject.element.firstChild, 'drag', {
+        details: { delta },
+      });
 
-    this.render(hbs`{{under-test}}`);
-    let subject = this.componentInstance;
+      assert.equal(calls, 1, 'callback was called');
+      assert.ok(hadRunloop, 'callback was called in runloop');
+      assert.ok(handledArgs.target, 'callback passed a target');
+      assert.equal(
+        handledArgs.details.delta,
+        delta,
+        'second argument can be present'
+      );
+    });
 
-    assert.throws(() => {
-      subject.addEventListener('.foo', 'click', () => {}, testedOptions);
-    }, /Called \w+ with selector not found in DOM: .foo/);
-  });
+    test(`${testName} adds event listener to non-child element`, async function(assert) {
+      assert.expect(5);
 
-  test(`${testName} throws when attached before rendering`, function(assert) {
-    assert.expect(1);
+      this.set('show', true);
+      render(hbs`{{#if show}}{{under-test}}{{/if}}<span class="foo"></span>`);
+      let subject = this.componentInstance;
 
-    let subject = this.Component.create();
+      let ranCallback = 0;
+      let hadRunloop = null;
+      let handledEvent = null;
+      let element = find('.foo');
 
-    assert.throws(() => {
-      subject.addEventListener('.foo', 'click', () => {}, testedOptions);
-    }, /Called \w+ with a css selector before the component was rendered/);
-  });
+      subject.addEventListener(
+        element,
+        'click',
+        event => {
+          ranCallback++;
+          hadRunloop = !!run.currentRunLoop;
+          handledEvent = event;
+        },
+        testedOptions
+      );
 
-  test(`${testName} adds event listener to non-child element in tagless component`, async function(assert) {
-    assert.expect(5);
+      await triggerEvent(element, 'click');
 
-    this.set('show', true);
-    this.render(
-      hbs`{{#if show}}{{under-test tagName=""}}{{/if}}<span class="foo"></span>`
-    );
-    let subject = this.componentInstance;
+      assert.equal(ranCallback, 1, 'callback was called once');
+      assert.ok(hadRunloop, 'callback was called in runloop');
+      assert.ok(!!handledEvent.target, 'callback passed a target');
+      assert.equal(
+        handledEvent.target.className,
+        'foo',
+        'target has the expected class'
+      );
 
-    let calls = 0;
-    let hadRunloop = null;
-    let handledEvent = null;
+      this.set('show', false);
 
-    subject.addEventListener(
-      find('.foo'),
-      'click',
-      event => {
+      // Trigger the event on the non-child element again, after the component
+      // is removed from DOM. The listener should not fire this time.
+      await triggerEvent(element, 'click');
+
+      assert.equal(ranCallback, 1, 'callback was not called a second time');
+    });
+
+    test(`${testName} throws when there is no element to attach to`, function(assert) {
+      assert.expect(1);
+
+      render(hbs`{{under-test}}`);
+      let subject = this.componentInstance;
+
+      assert.throws(() => {
+        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+      }, /Called \w+ with selector not found in DOM: .foo/);
+    });
+
+    test(`${testName} throws when attached before rendering`, function(assert) {
+      assert.expect(1);
+
+      let subject = this.Component.create();
+
+      assert.throws(() => {
+        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+      }, /Called \w+ with a css selector before the component was rendered/);
+    });
+
+    test(`${testName} adds event listener to non-child element in tagless component`, async function(assert) {
+      assert.expect(5);
+
+      this.set('show', true);
+      render(
+        hbs`{{#if show}}{{under-test tagName=""}}{{/if}}<span class="foo"></span>`
+      );
+      let subject = this.componentInstance;
+
+      let calls = 0;
+      let hadRunloop = null;
+      let handledEvent = null;
+
+      subject.addEventListener(
+        find('.foo'),
+        'click',
+        event => {
+          calls++;
+          hadRunloop = !!run.currentRunLoop;
+          handledEvent = event;
+        },
+        testedOptions
+      );
+
+      await triggerEvent('.foo', 'click');
+
+      assert.equal(calls, 1, 'callback was called');
+      assert.ok(hadRunloop, 'callback was called in runloop');
+      assert.ok(!!handledEvent.target, 'callback passed a target');
+      assert.equal(
+        handledEvent.target.className,
+        'foo',
+        'target has the expected class'
+      );
+
+      this.set('show', false);
+
+      // Trigger the event on the non-child element again, after the component
+      // is removed from DOM. The listener should not fire this time.
+      await triggerEvent('.foo', 'click');
+
+      assert.equal(calls, 1, 'callback was not called again');
+    });
+
+    test(`${testName} throws when using a string selector in a tagless component`, function(assert) {
+      assert.expect(1);
+
+      render(hbs`{{under-test tagName=""}}<span class="foo"></span>`);
+      let subject = this.componentInstance;
+
+      assert.throws(() => {
+        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+      }, /Must provide an element/);
+    });
+
+    test(`${testName} listeners on different contexts can be torn down without impacting other contexts`, function(assert) {
+      assert.expect(2);
+
+      let testContext = this;
+      this.owner.register(
+        'component:under-test-a',
+        Component.extend(ContextBoundEventListenersMixin, {
+          init() {
+            this._super(...arguments);
+            testContext.subjectA = this;
+          },
+        })
+      );
+      this.owner.register(
+        'component:under-test-b',
+        Component.extend(ContextBoundEventListenersMixin, {
+          init() {
+            this._super(...arguments);
+            testContext.subjectB = this;
+          },
+        })
+      );
+
+      this.set('showA', true);
+      render(
+        hbs`{{#if showA}}{{under-test-a}}{{/if}}{{under-test-b}}<span class="foo"></span>`
+      );
+
+      let { subjectA, subjectB } = this;
+
+      let target = find('.foo');
+
+      let calls = 0;
+      let callback = () => {
         calls++;
-        hadRunloop = !!run.currentRunLoop;
-        handledEvent = event;
-      },
-      testedOptions
-    );
+      };
+      subjectA.addEventListener(target, 'click', callback, testedOptions);
+      subjectB.addEventListener(target, 'click', callback, testedOptions);
 
-    await triggerEvent('.foo', 'click');
+      target.click();
+      assert.equal(calls, 2, 'two callbacks called');
 
-    assert.equal(calls, 1, 'callback was called');
-    assert.ok(hadRunloop, 'callback was called in runloop');
-    assert.ok(!!handledEvent.target, 'callback passed a target');
-    assert.equal(
-      handledEvent.target.className,
-      'foo',
-      'target has the expected class'
-    );
+      this.set('showA', false);
 
-    this.set('show', false);
+      target.click();
+      assert.equal(calls, 3, 'one more callback called for remaining context');
+    });
 
-    // Trigger the event on the non-child element again, after the component
-    // is removed from DOM. The listener should not fire this time.
-    await triggerEvent('.foo', 'click');
+    test(`${testName} listeners are called with correct scope`, function(assert) {
+      assert.expect(2);
 
-    assert.equal(calls, 1, 'callback was not called again');
+      let testContext = this;
+
+      this.owner.register(
+        'component:under-test-a',
+        Component.extend(ContextBoundEventListenersMixin, {
+          init() {
+            this._super(...arguments);
+            testContext.subjectA = this;
+          },
+        })
+      );
+      this.owner.register(
+        'component:under-test-b',
+        Component.extend(ContextBoundEventListenersMixin, {
+          init() {
+            this._super(...arguments);
+            testContext.subjectB = this;
+          },
+        })
+      );
+
+      render(hbs`{{under-test-a}}{{under-test-b}}<span class="foo"></span>`);
+
+      let { subjectA, subjectB } = this;
+      let target = find('.foo');
+      let assertScope = scope => {
+        return function() {
+          assert.equal(this, scope);
+        };
+      };
+
+      subjectA.addEventListener(
+        target,
+        'click',
+        assertScope(subjectA),
+        testedOptions
+      );
+      subjectB.addEventListener(
+        target,
+        'click',
+        assertScope(subjectB),
+        testedOptions
+      );
+
+      target.click();
+    });
+
+    test(`${testName.replace(
+      'add',
+      'remove'
+    )} removes event listener from child element`, async function(assert) {
+      assert.expect(1);
+
+      this.owner.register(
+        'template:components/under-test',
+        hbs`<span class="foo"></span>`
+      );
+      render(hbs`{{under-test}}`);
+      let subject = this.componentInstance;
+      let calls = 0;
+      let listener = () => {
+        calls++;
+      };
+
+      subject.addEventListener('.foo', 'click', listener, testedOptions);
+
+      subject.removeEventListener('.foo', 'click', listener, testedOptions);
+
+      await triggerEvent(subject.element.firstChild, 'click');
+
+      assert.equal(calls, 0, 'callback was not called');
+    });
+
+    test(`${testName} adds event listener when an element is passed in from a service and removes listener when instance is destroyed`, async function(assert) {
+      assert.expect(6);
+
+      let serviceName = 'service:under-test';
+
+      this.owner.register(
+        'service:under-test',
+        Service.extend(ContextBoundEventListenersMixin)
+      );
+
+      let factory = this.owner.factoryFor
+        ? this.owner.factoryFor(serviceName)
+        : this.owner._lookupFactory(serviceName);
+      let subject = factory.create();
+
+      render(hbs`<span class="foo"></span>`);
+
+      let calls = 0;
+      let hadRunloop = null;
+      let handledEvent = null;
+      subject.addEventListener(
+        find('.foo'),
+        'click',
+        event => {
+          calls++;
+          hadRunloop = !!run.currentRunLoop;
+          handledEvent = event;
+        },
+        testedOptions
+      );
+
+      await triggerEvent('.foo', 'click');
+
+      assert.equal(calls, 1, 'callback was called');
+      assert.ok(hadRunloop, 'callback was called in runloop');
+      assert.ok(!!handledEvent.target, 'callback passed a target');
+      assert.equal(
+        handledEvent.target.className,
+        'foo',
+        'target has the expected class'
+      );
+
+      run(() => subject.destroy()); // Listeners should be removed when the service is destroyed
+
+      await triggerEvent('.foo', 'click');
+
+      assert.equal(
+        calls,
+        1,
+        'callback is not called again once the instance is destroyed'
+      );
+      assert.notOk(subject._listeners);
+    });
+
+    test(`${testName} throws when a css selector is passed in from a service instance`, async function(assert) {
+      assert.expect(1);
+
+      let serviceName = 'service:under-test';
+
+      this.owner.register(
+        'service:under-test',
+        Service.extend(ContextBoundEventListenersMixin)
+      );
+
+      let factory = this.owner.factoryFor
+        ? this.owner.factoryFor(serviceName)
+        : this.owner._lookupFactory(serviceName);
+      let subject = factory.create();
+
+      assert.throws(() => {
+        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+      }, /Must provide an element/);
+    });
   });
 
-  test(`${testName} throws when using a string selector in a tagless component`, function(assert) {
-    assert.expect(1);
+  test('addEventListener(_,_,{passive: false}) permits stopPropogation', async function(assert) {
+    assert.expect(2);
 
-    this.render(hbs`{{under-test tagName=""}}<span class="foo"></span>`);
+    this.owner.register(
+      'template:components/under-test',
+      hbs`<span class="outer"><span class="inner"></span></span>`
+    );
+    await render(hbs`{{under-test}}`);
     let subject = this.componentInstance;
 
-    assert.throws(() => {
-      subject.addEventListener('.foo', 'click', () => {}, testedOptions);
-    }, /Must provide an element/);
+    let outerCalls = 0;
+    subject.addEventListener('.outer', 'click', () => outerCalls++);
+
+    let innerCalls = 0;
+    subject.addEventListener(
+      '.inner',
+      'click',
+      e => {
+        innerCalls++;
+        e.stopPropagation();
+      },
+      { passive: false }
+    );
+
+    await triggerEvent(subject.element.firstChild.firstChild, 'click', {
+      bubbles: true,
+    });
+
+    assert.equal(outerCalls, 0, 'outer callback never fires');
+    assert.equal(innerCalls, 1, 'inner callback fires');
   });
 
-  test(`${testName} listeners on different contexts can be torn down without impacting other contexts`, function(assert) {
+  test('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
     assert.expect(2);
 
-    let testContext = this;
-    this.register(
-      'component:under-test-a',
-      Component.extend(ContextBoundEventListenersMixin, {
-        init() {
-          this._super(...arguments);
-          testContext.subjectA = this;
-        },
-      })
-    );
-    this.register(
-      'component:under-test-b',
-      Component.extend(ContextBoundEventListenersMixin, {
-        init() {
-          this._super(...arguments);
-          testContext.subjectB = this;
-        },
-      })
-    );
-
-    this.set('showA', true);
-    this.render(
-      hbs`{{#if showA}}{{under-test-a}}{{/if}}{{under-test-b}}<span class="foo"></span>`
-    );
-
-    let { subjectA, subjectB } = this;
-
-    let target = find('.foo');
-
-    let calls = 0;
-    let callback = () => {
-      calls++;
-    };
-    subjectA.addEventListener(target, 'click', callback, testedOptions);
-    subjectB.addEventListener(target, 'click', callback, testedOptions);
-
-    target.click();
-    assert.equal(calls, 2, 'two callbacks called');
-
-    this.set('showA', false);
-
-    target.click();
-    assert.equal(calls, 3, 'one more callback called for remaining context');
-  });
-
-  test(`${testName} listeners are called with correct scope`, function(assert) {
-    assert.expect(2);
-
-    let testContext = this;
-
-    this.register(
-      'component:under-test-a',
-      Component.extend(ContextBoundEventListenersMixin, {
-        init() {
-          this._super(...arguments);
-          testContext.subjectA = this;
-        },
-      })
-    );
-    this.register(
-      'component:under-test-b',
-      Component.extend(ContextBoundEventListenersMixin, {
-        init() {
-          this._super(...arguments);
-          testContext.subjectB = this;
-        },
-      })
-    );
-
-    this.render(hbs`{{under-test-a}}{{under-test-b}}<span class="foo"></span>`);
-
-    let { subjectA, subjectB } = this;
-    let target = find('.foo');
-    let assertScope = scope => {
-      return function() {
-        assert.equal(this, scope);
-      };
-    };
-
-    subjectA.addEventListener(
-      target,
-      'click',
-      assertScope(subjectA),
-      testedOptions
-    );
-    subjectB.addEventListener(
-      target,
-      'click',
-      assertScope(subjectB),
-      testedOptions
-    );
-
-    target.click();
-  });
-
-  test(`${testName.replace(
-    'add',
-    'remove'
-  )} removes event listener from child element`, async function(assert) {
-    assert.expect(1);
-
-    this.register(
+    this.owner.register(
       'template:components/under-test',
       hbs`<span class="foo"></span>`
     );
-    this.render(hbs`{{under-test}}`);
+    await render(hbs`{{under-test}}`);
     let subject = this.componentInstance;
+
     let calls = 0;
     let listener = () => {
       calls++;
     };
+    let element = find('.foo');
 
-    subject.addEventListener('.foo', 'click', listener, testedOptions);
+    subject.addEventListener('.foo', 'click', listener, { once: true });
 
-    subject.removeEventListener('.foo', 'click', listener, testedOptions);
+    await triggerEvent(element, 'click');
+    assert.equal(calls, 1, 'callback was called once');
 
-    await triggerEvent(subject.element.firstChild, 'click');
-
-    assert.equal(calls, 0, 'callback was not called');
+    await triggerEvent(element, 'click');
+    assert.equal(calls, 1, 'callback was called once');
   });
-
-  test(`${testName} adds event listener when an element is passed in from a service and removes listener when instance is destroyed`, async function(assert) {
-    assert.expect(6);
-
-    let serviceName = 'service:under-test';
-    let owner = getOwner(this);
-
-    owner.register(
-      'service:under-test',
-      Service.extend(ContextBoundEventListenersMixin)
-    );
-
-    let factory = owner.factoryFor
-      ? owner.factoryFor(serviceName)
-      : owner._lookupFactory(serviceName);
-    let subject = factory.create();
-
-    this.render(hbs`<span class="foo"></span>`);
-
-    let calls = 0;
-    let hadRunloop = null;
-    let handledEvent = null;
-    subject.addEventListener(
-      find('.foo'),
-      'click',
-      event => {
-        calls++;
-        hadRunloop = !!run.currentRunLoop;
-        handledEvent = event;
-      },
-      testedOptions
-    );
-
-    await triggerEvent('.foo', 'click');
-
-    assert.equal(calls, 1, 'callback was called');
-    assert.ok(hadRunloop, 'callback was called in runloop');
-    assert.ok(!!handledEvent.target, 'callback passed a target');
-    assert.equal(
-      handledEvent.target.className,
-      'foo',
-      'target has the expected class'
-    );
-
-    run(() => subject.destroy()); // Listeners should be removed when the service is destroyed
-
-    await triggerEvent('.foo', 'click');
-
-    assert.equal(
-      calls,
-      1,
-      'callback is not called again once the instance is destroyed'
-    );
-    assert.notOk(subject._listeners);
-  });
-
-  test(`${testName} throws when a css selector is passed in from a service instance`, async function(assert) {
-    assert.expect(1);
-
-    let serviceName = 'service:under-test';
-    let owner = getOwner(this);
-
-    owner.register(
-      'service:under-test',
-      Service.extend(ContextBoundEventListenersMixin)
-    );
-
-    let factory = owner.factoryFor
-      ? owner.factoryFor(serviceName)
-      : owner._lookupFactory(serviceName);
-    let subject = factory.create();
-
-    assert.throws(() => {
-      subject.addEventListener('.foo', 'click', () => {}, testedOptions);
-    }, /Must provide an element/);
-  });
-});
-
-test('addEventListener(_,_,{passive: false}) permits stopPropogation', async function(assert) {
-  assert.expect(2);
-
-  this.register(
-    'template:components/under-test',
-    hbs`<span class="outer"><span class="inner"></span></span>`
-  );
-  this.render(hbs`{{under-test}}`);
-  let subject = this.componentInstance;
-
-  let outerCalls = 0;
-  subject.addEventListener('.outer', 'click', () => outerCalls++);
-
-  let innerCalls = 0;
-  subject.addEventListener(
-    '.inner',
-    'click',
-    e => {
-      innerCalls++;
-      e.stopPropagation();
-    },
-    { passive: false }
-  );
-
-  await triggerEvent(subject.element.firstChild.firstChild, 'click', {
-    bubbles: true,
-  });
-
-  assert.equal(outerCalls, 0, 'outer callback never fires');
-  assert.equal(innerCalls, 1, 'inner callback fires');
-});
-
-test('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
-  assert.expect(2);
-
-  this.register(
-    'template:components/under-test',
-    hbs`<span class="foo"></span>`
-  );
-  this.render(hbs`{{under-test}}`);
-  let subject = this.componentInstance;
-
-  let calls = 0;
-  let listener = () => {
-    calls++;
-  };
-  let element = find('.foo');
-
-  subject.addEventListener('.foo', 'click', listener, { once: true });
-
-  await triggerEvent(element, 'click');
-  assert.equal(calls, 1, 'callback was called once');
-
-  await triggerEvent(element, 'click');
-  assert.equal(calls, 1, 'callback was called once');
 });

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -5,9 +5,8 @@ import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find, triggerEvent } from '@ember/test-helpers';
 import ContextBoundEventListenersMixin from 'ember-lifeline/mixins/dom';
-import { find, triggerEvent } from 'ember-native-dom-helpers';
 
 module('ember-lifeline/mixins/dom', function(hooks) {
   setupRenderingTest(hooks);
@@ -49,13 +48,13 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         hbs`<span class="foo"></span>`
       );
       await render(hbs`{{under-test}}`);
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       let calls = 0;
       let hadRunloop = null;
       let handledEvent = null;
 
-      subject.addEventListener(
+      component.addEventListener(
         '.foo',
         'click',
         event => {
@@ -66,7 +65,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         testedOptions
       );
 
-      subject.element.firstChild.dispatchEvent(new Event('click'));
+      component.element.firstChild.dispatchEvent(new Event('click'));
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -86,13 +85,13 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         hbs`<span class="foo"></span>`
       );
       await render(hbs`{{under-test}}`);
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       let calls = 0;
       let hadRunloop = null;
       let handledEvent = null;
 
-      subject.addEventListener(
+      component.addEventListener(
         'click',
         event => {
           calls++;
@@ -102,7 +101,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         testedOptions
       );
 
-      subject.element.dispatchEvent(new Event('click'));
+      component.element.dispatchEvent(new Event('click'));
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -122,13 +121,13 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         hbs`<span class="foo"></span>`
       );
       await render(hbs`{{under-test}}`);
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       let calls = 0;
       let hadRunloop = null;
       let handledArgs = null;
 
-      subject.addEventListener(
+      component.addEventListener(
         '.foo',
         'drag',
         (...args) => {
@@ -140,7 +139,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       );
 
       let delta = {};
-      await triggerEvent(subject.element.firstChild, 'drag', {
+      await triggerEvent(component.element.firstChild, 'drag', {
         details: { delta },
       });
 
@@ -161,14 +160,14 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       await render(
         hbs`{{#if show}}{{under-test}}{{/if}}<span class="foo"></span>`
       );
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       let ranCallback = 0;
       let hadRunloop = null;
       let handledEvent = null;
       let element = find('.foo');
 
-      subject.addEventListener(
+      component.addEventListener(
         element,
         'click',
         event => {
@@ -203,20 +202,20 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.expect(1);
 
       await render(hbs`{{under-test}}`);
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       assert.throws(() => {
-        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+        component.addEventListener('.foo', 'click', () => {}, testedOptions);
       }, /Called \w+ with selector not found in DOM: .foo/);
     });
 
     test(`${testName} throws when attached before rendering`, function(assert) {
       assert.expect(1);
 
-      let subject = this.Component.create();
+      let component = this.Component.create();
 
       assert.throws(() => {
-        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+        component.addEventListener('.foo', 'click', () => {}, testedOptions);
       }, /Called \w+ with a css selector before the component was rendered/);
     });
 
@@ -227,13 +226,13 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       await render(
         hbs`{{#if show}}{{under-test tagName=""}}{{/if}}<span class="foo"></span>`
       );
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       let calls = 0;
       let hadRunloop = null;
       let handledEvent = null;
 
-      subject.addEventListener(
+      component.addEventListener(
         find('.foo'),
         'click',
         event => {
@@ -268,10 +267,10 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       assert.expect(1);
 
       await render(hbs`{{under-test tagName=""}}<span class="foo"></span>`);
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
 
       assert.throws(() => {
-        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+        component.addEventListener('.foo', 'click', () => {}, testedOptions);
       }, /Must provide an element/);
     });
 
@@ -386,23 +385,23 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         hbs`<span class="foo"></span>`
       );
       await render(hbs`{{under-test}}`);
-      let subject = this.componentInstance;
+      let component = this.componentInstance;
       let calls = 0;
       let listener = () => {
         calls++;
       };
 
-      subject.addEventListener('.foo', 'click', listener, testedOptions);
+      component.addEventListener('.foo', 'click', listener, testedOptions);
 
-      subject.removeEventListener('.foo', 'click', listener, testedOptions);
+      component.removeEventListener('.foo', 'click', listener, testedOptions);
 
-      await triggerEvent(subject.element.firstChild, 'click');
+      await triggerEvent(component.element.firstChild, 'click');
 
       assert.equal(calls, 0, 'callback was not called');
     });
 
     test(`${testName} adds event listener when an element is passed in from a service and removes listener when instance is destroyed`, async function(assert) {
-      assert.expect(6);
+      assert.expect(5);
 
       let serviceName = 'service:under-test';
 
@@ -414,14 +413,14 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       let factory = this.owner.factoryFor
         ? this.owner.factoryFor(serviceName)
         : this.owner._lookupFactory(serviceName);
-      let subject = factory.create();
+      let component = factory.create();
 
       await render(hbs`<span class="foo"></span>`);
 
       let calls = 0;
       let hadRunloop = null;
       let handledEvent = null;
-      subject.addEventListener(
+      component.addEventListener(
         find('.foo'),
         'click',
         event => {
@@ -443,7 +442,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         'target has the expected class'
       );
 
-      run(() => subject.destroy()); // Listeners should be removed when the service is destroyed
+      run(() => component.destroy()); // Listeners should be removed when the service is destroyed
 
       await triggerEvent('.foo', 'click');
 
@@ -452,7 +451,6 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         1,
         'callback is not called again once the instance is destroyed'
       );
-      assert.notOk(subject._listeners);
     });
 
     test(`${testName} throws when a css selector is passed in from a service instance`, async function(assert) {
@@ -468,10 +466,10 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       let factory = this.owner.factoryFor
         ? this.owner.factoryFor(serviceName)
         : this.owner._lookupFactory(serviceName);
-      let subject = factory.create();
+      let component = factory.create();
 
       assert.throws(() => {
-        subject.addEventListener('.foo', 'click', () => {}, testedOptions);
+        component.addEventListener('.foo', 'click', () => {}, testedOptions);
       }, /Must provide an element/);
     });
   });
@@ -484,13 +482,13 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       hbs`<span class="outer"><span class="inner"></span></span>`
     );
     await render(hbs`{{under-test}}`);
-    let subject = this.componentInstance;
+    let component = this.componentInstance;
 
     let outerCalls = 0;
-    subject.addEventListener('.outer', 'click', () => outerCalls++);
+    component.addEventListener('.outer', 'click', () => outerCalls++);
 
     let innerCalls = 0;
-    subject.addEventListener(
+    component.addEventListener(
       '.inner',
       'click',
       e => {
@@ -500,7 +498,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       { passive: false }
     );
 
-    await triggerEvent(subject.element.firstChild.firstChild, 'click', {
+    await triggerEvent(component.element.firstChild.firstChild, 'click', {
       bubbles: true,
     });
 
@@ -516,7 +514,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
       hbs`<span class="foo"></span>`
     );
     await render(hbs`{{under-test}}`);
-    let subject = this.componentInstance;
+    let component = this.componentInstance;
 
     let calls = 0;
     let listener = () => {
@@ -524,7 +522,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
     };
     let element = find('.foo');
 
-    subject.addEventListener('.foo', 'click', listener, { once: true });
+    component.addEventListener('.foo', 'click', listener, { once: true });
 
     await triggerEvent(element, 'click');
     assert.equal(calls, 1, 'callback was called once');

--- a/tests/unit/poll-task-test.js
+++ b/tests/unit/poll-task-test.js
@@ -1,7 +1,6 @@
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import wait from 'ember-test-helpers/wait';
 import {
   runTask,
   pollTask,
@@ -11,221 +10,223 @@ import {
   runDisposables,
 } from 'ember-lifeline';
 
-module('ember-lifeline/poll-task', {
-  beforeEach() {
+import { settled } from '@ember/test-helpers';
+
+module('ember-lifeline/poll-task', function(hooks) {
+  hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend();
-  },
 
-  afterEach() {
-    runDisposables(this.obj);
-    setShouldPoll(null);
-  },
+    this.subject = function({ force } = {}) {
+      if (force && this._subject) {
+        run(this._subject, 'destroy');
+        this._subject = null;
+      }
 
-  subject({ force } = {}) {
-    if (force && this._subject) {
-      run(this._subject, 'destroy');
-      this._subject = null;
-    }
+      if (this._subject) {
+        return this._subject;
+      }
 
-    if (this._subject) {
-      return this._subject;
-    }
-
-    return (this._subject = this.BaseObject.create(...arguments));
-  },
-});
-
-test('pollTask provides ability to poll with callback provided', function(assert) {
-  assert.expect(2);
-  setShouldPoll(() => true);
-  this.obj = this.subject();
-  let calledTimes = 0;
-
-  pollTask(this.obj, next => {
-    calledTimes++;
-
-    if (calledTimes === 5) {
-      assert.ok(true, 'polled successfully');
-    } else {
-      runTask(this.obj, next, 5);
-    }
+      return (this._subject = this.BaseObject.create(...arguments));
+    };
   });
 
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+  hooks.afterEach(function() {
+    runDisposables(this.obj);
+    setShouldPoll(null);
+  });
 
-  // ensure that pending pollTask's are not running
-  return wait();
-});
+  test('pollTask provides ability to poll with callback provided', function(assert) {
+    assert.expect(2);
+    setShouldPoll(() => true);
+    this.obj = this.subject();
+    let calledTimes = 0;
 
-test('pollTask provides ability to poll with method provided', function(assert) {
-  assert.expect(3);
-  setShouldPoll(() => true);
-  let calledTimes = 0;
-  let obj = (this.obj = this.subject({
-    run(next) {
+    pollTask(this.obj, next => {
       calledTimes++;
 
       if (calledTimes === 5) {
-        assert.equal(this, obj, 'context is correct');
         assert.ok(true, 'polled successfully');
       } else {
-        runTask(obj, next, 5);
+        runTask(this.obj, next, 5);
       }
-    },
-  }));
+    });
 
-  pollTask(this.obj, 'run');
-
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
-
-  // ensure that pending pollTask's are not running
-  return wait();
-});
-
-test('pollTask calls callback once in testing mode', function(assert) {
-  assert.expect(2);
-  let obj = (this.obj = this.subject());
-  let calledTimes = 0;
-
-  pollTask(this.obj, next => {
-    calledTimes++;
-
-    if (calledTimes > 1) {
-      assert.ok(false, 'should not be called more than once');
-    }
-
-    runTask(obj, next, 5);
-  });
-
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
-
-  // test string form
-  this.obj.run = function(next) {
-    calledTimes++;
-
-    runTask(obj, next, 5);
-  };
-
-  pollTask(this.obj, 'run');
-  assert.equal(calledTimes, 2, 'pollTask executed with method name properly');
-
-  // ensure that pending pollTask's are not running
-  return wait();
-});
-
-test('pollTask next tick can be incremented via test helper with callback', function(assert) {
-  assert.expect(2);
-  this.obj = this.subject();
-  let calledTimes = 0;
-
-  let token = pollTask(this.obj, next => {
-    calledTimes++;
-
-    if (calledTimes > 2) {
-      assert.ok(false, 'should not be called more than twice');
-    }
-
-    runTask(this.obj, next, 5);
-  });
-
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
-
-  return wait().then(function() {
-    pollTaskFor(token);
-
-    assert.equal(
-      calledTimes,
-      2,
-      'poll task argument was invoked after ticking'
-    );
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
 
     // ensure that pending pollTask's are not running
-    return wait();
+    return settled();
   });
-});
 
-test('pollTask next tick can be incremented via test helper with method name', function(assert) {
-  assert.expect(2);
-  let calledTimes = 0;
-  let obj = (this.obj = this.subject({
-    run(next) {
+  test('pollTask provides ability to poll with method provided', function(assert) {
+    assert.expect(3);
+    setShouldPoll(() => true);
+    let calledTimes = 0;
+    let obj = (this.obj = this.subject({
+      run(next) {
+        calledTimes++;
+
+        if (calledTimes === 5) {
+          assert.equal(this, obj, 'context is correct');
+          assert.ok(true, 'polled successfully');
+        } else {
+          runTask(obj, next, 5);
+        }
+      },
+    }));
+
+    pollTask(this.obj, 'run');
+
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+
+    // ensure that pending pollTask's are not running
+    return settled();
+  });
+
+  test('pollTask calls callback once in testing mode', function(assert) {
+    assert.expect(2);
+    let obj = (this.obj = this.subject());
+    let calledTimes = 0;
+
+    pollTask(this.obj, next => {
+      calledTimes++;
+
+      if (calledTimes > 1) {
+        assert.ok(false, 'should not be called more than once');
+      }
+
+      runTask(obj, next, 5);
+    });
+
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+
+    // test string form
+    this.obj.run = function(next) {
+      calledTimes++;
+
+      runTask(obj, next, 5);
+    };
+
+    pollTask(this.obj, 'run');
+    assert.equal(calledTimes, 2, 'pollTask executed with method name properly');
+
+    // ensure that pending pollTask's are not running
+    return settled();
+  });
+
+  test('pollTask next tick can be incremented via test helper with callback', function(assert) {
+    assert.expect(2);
+    this.obj = this.subject();
+    let calledTimes = 0;
+
+    let token = pollTask(this.obj, next => {
       calledTimes++;
 
       if (calledTimes > 2) {
         assert.ok(false, 'should not be called more than twice');
       }
 
-      runTask(obj, next, 5);
-    },
-  }));
+      runTask(this.obj, next, 5);
+    });
 
-  let token = pollTask(this.obj, 'run');
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
 
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+    return settled().then(function() {
+      pollTaskFor(token);
 
-  return wait().then(function() {
-    pollTaskFor(token);
+      assert.equal(
+        calledTimes,
+        2,
+        'poll task argument was invoked after ticking'
+      );
 
-    assert.equal(
-      calledTimes,
-      2,
-      'poll task argument was invoked after ticking'
-    );
+      // ensure that pending pollTask's are not running
+      return settled();
+    });
+  });
+
+  test('pollTask next tick can be incremented via test helper with method name', function(assert) {
+    assert.expect(2);
+    let calledTimes = 0;
+    let obj = (this.obj = this.subject({
+      run(next) {
+        calledTimes++;
+
+        if (calledTimes > 2) {
+          assert.ok(false, 'should not be called more than twice');
+        }
+
+        runTask(obj, next, 5);
+      },
+    }));
+
+    let token = pollTask(this.obj, 'run');
+
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+
+    return settled().then(function() {
+      pollTaskFor(token);
+
+      assert.equal(
+        calledTimes,
+        2,
+        'poll task argument was invoked after ticking'
+      );
+
+      // ensure that pending pollTask's are not running
+      return settled();
+    });
+  });
+
+  test('pollTask cannot advance a poll that has not been scheduled', function(assert) {
+    assert.expect(3);
+
+    this.obj = this.subject();
+    let calledTimes = 0;
+
+    let token = pollTask(this.obj, () => {
+      calledTimes++;
+
+      if (calledTimes > 2) {
+        assert.ok(false, 'should not be called more than twice');
+      }
+    });
+
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+
+    assert.throws(function() {
+      pollTaskFor(token);
+    }, `You cannot advance pollTask '${token}' when \`next\` has not been called.`);
+
+    assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
 
     // ensure that pending pollTask's are not running
-    return wait();
-  });
-});
-
-test('pollTask cannot advance a poll that has not been scheduled', function(assert) {
-  assert.expect(3);
-
-  this.obj = this.subject();
-  let calledTimes = 0;
-
-  let token = pollTask(this.obj, () => {
-    calledTimes++;
-
-    if (calledTimes > 2) {
-      assert.ok(false, 'should not be called more than twice');
-    }
+    return settled();
   });
 
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+  test('pollTask can be manually cleared', function(assert) {
+    assert.expect(3);
+    this.obj = this.subject();
 
-  assert.throws(function() {
-    pollTaskFor(token);
-  }, `You cannot advance pollTask '${token}' when \`next\` has not been called.`);
+    let token = pollTask(this.obj, next => {
+      runTask(this.obj, next);
+    });
 
-  assert.equal(calledTimes, 1, 'poll task argument was invoked initially');
+    cancelPoll(token);
 
-  // ensure that pending pollTask's are not running
-  return wait();
-});
+    assert.throws(() => {
+      pollTaskFor(token);
+    }, new RegExp(`You cannot advance pollTask '${token}' when \`next\` has not been called.`));
 
-test('pollTask can be manually cleared', function(assert) {
-  assert.expect(3);
-  this.obj = this.subject();
+    this.obj = this.subject({ force: true });
 
-  let token = pollTask(this.obj, next => {
-    runTask(this.obj, next);
-  });
+    token = pollTask(this.obj, next => {
+      assert.ok(true, 'pollTask was called');
+      runTask(this.obj, next, 5);
+    });
 
-  cancelPoll(token);
-
-  assert.throws(() => {
-    pollTaskFor(token);
-  }, new RegExp(`You cannot advance pollTask '${token}' when \`next\` has not been called.`));
-
-  this.obj = this.subject({ force: true });
-
-  token = pollTask(this.obj, next => {
-    assert.ok(true, 'pollTask was called');
-    runTask(this.obj, next, 5);
-  });
-
-  // ensure that pending pollTask's are not running
-  return wait().then(() => {
-    pollTaskFor(token);
+    // ensure that pending pollTask's are not running
+    return settled().then(() => {
+      pollTaskFor(token);
+    });
   });
 });

--- a/tests/unit/poll-task-test.js
+++ b/tests/unit/poll-task-test.js
@@ -16,17 +16,17 @@ module('ember-lifeline/poll-task', function(hooks) {
   hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend();
 
-    this.subject = function({ force } = {}) {
-      if (force && this._subject) {
-        run(this._subject, 'destroy');
-        this._subject = null;
+    this.getComponent = function({ force } = {}) {
+      if (force && this._component) {
+        run(this._component, 'destroy');
+        this._component = null;
       }
 
-      if (this._subject) {
-        return this._subject;
+      if (this._component) {
+        return this._component;
       }
 
-      return (this._subject = this.BaseObject.create(...arguments));
+      return (this._component = this.BaseObject.create(...arguments));
     };
   });
 
@@ -38,7 +38,7 @@ module('ember-lifeline/poll-task', function(hooks) {
   test('pollTask provides ability to poll with callback provided', function(assert) {
     assert.expect(2);
     setShouldPoll(() => true);
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let calledTimes = 0;
 
     pollTask(this.obj, next => {
@@ -61,7 +61,7 @@ module('ember-lifeline/poll-task', function(hooks) {
     assert.expect(3);
     setShouldPoll(() => true);
     let calledTimes = 0;
-    let obj = (this.obj = this.subject({
+    let obj = (this.obj = this.getComponent({
       run(next) {
         calledTimes++;
 
@@ -84,7 +84,7 @@ module('ember-lifeline/poll-task', function(hooks) {
 
   test('pollTask calls callback once in testing mode', function(assert) {
     assert.expect(2);
-    let obj = (this.obj = this.subject());
+    let obj = (this.obj = this.getComponent());
     let calledTimes = 0;
 
     pollTask(this.obj, next => {
@@ -115,7 +115,7 @@ module('ember-lifeline/poll-task', function(hooks) {
 
   test('pollTask next tick can be incremented via test helper with callback', function(assert) {
     assert.expect(2);
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let calledTimes = 0;
 
     let token = pollTask(this.obj, next => {
@@ -147,7 +147,7 @@ module('ember-lifeline/poll-task', function(hooks) {
   test('pollTask next tick can be incremented via test helper with method name', function(assert) {
     assert.expect(2);
     let calledTimes = 0;
-    let obj = (this.obj = this.subject({
+    let obj = (this.obj = this.getComponent({
       run(next) {
         calledTimes++;
 
@@ -180,7 +180,7 @@ module('ember-lifeline/poll-task', function(hooks) {
   test('pollTask cannot advance a poll that has not been scheduled', function(assert) {
     assert.expect(3);
 
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let calledTimes = 0;
 
     let token = pollTask(this.obj, () => {
@@ -205,7 +205,7 @@ module('ember-lifeline/poll-task', function(hooks) {
 
   test('pollTask can be manually cleared', function(assert) {
     assert.expect(3);
-    this.obj = this.subject();
+    this.obj = this.getComponent();
 
     let token = pollTask(this.obj, next => {
       runTask(this.obj, next);
@@ -217,7 +217,7 @@ module('ember-lifeline/poll-task', function(hooks) {
       pollTaskFor(token);
     }, new RegExp(`You cannot advance pollTask '${token}' when \`next\` has not been called.`));
 
-    this.obj = this.subject({ force: true });
+    this.obj = this.getComponent({ force: true });
 
     token = pollTask(this.obj, next => {
       assert.ok(true, 'pollTask was called');

--- a/tests/unit/run-task-test.js
+++ b/tests/unit/run-task-test.js
@@ -9,176 +9,176 @@ import {
   runDisposables,
 } from 'ember-lifeline';
 
-module('ember-lifeline/run-task', {
-  beforeEach() {
+module('ember-lifeline/run-task', function(hooks) {
+  hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend();
-  },
 
-  afterEach() {
+    this.subject = function() {
+      if (this._subject) {
+        return this._subject;
+      }
+
+      return (this._subject = this.BaseObject.create(...arguments));
+    };
+  });
+
+  hooks.afterEach(function() {
     runDisposables(this.obj);
-  },
+  });
 
-  subject() {
-    if (this._subject) {
-      return this._subject;
-    }
+  test('invokes async tasks', function(assert) {
+    assert.expect(2);
 
-    return (this._subject = this.BaseObject.create(...arguments));
-  },
-});
+    this.obj = this.subject();
+    let done = assert.async();
+    let hasRun = false;
 
-test('invokes async tasks', function(assert) {
-  assert.expect(2);
+    runTask(
+      this.obj,
+      () => {
+        hasRun = true;
+        assert.ok(true, 'callback was called');
+        done();
+      },
+      0
+    );
 
-  this.obj = this.subject();
-  let done = assert.async();
-  let hasRun = false;
-
-  runTask(
-    this.obj,
-    () => {
-      hasRun = true;
-      assert.ok(true, 'callback was called');
-      done();
-    },
-    0
-  );
-
-  assert.notOk(hasRun, 'callback should not have run yet');
-});
-
-test('invokes named functions as async tasks', function(assert) {
-  assert.expect(3);
-  let done = assert.async();
-  let obj = (this.obj = this.subject({
-    run() {
-      hasRun = true;
-      assert.equal(this, obj, 'context is correct');
-      assert.ok(true, 'callback was called');
-      done();
-    },
-  }));
-  let hasRun = false;
-
-  runTask(this.obj, 'run', 0);
-
-  assert.notOk(hasRun, 'callback should not have run yet');
-});
-
-test('invokes async tasks with delay', function(assert) {
-  assert.expect(3);
-  this.obj = this.subject();
-  let done = assert.async();
-  let hasRun = false;
-
-  runTask(
-    this.obj,
-    () => {
-      hasRun = true;
-      assert.ok(true, 'callback was called');
-      done();
-    },
-    10
-  );
-
-  window.setTimeout(() => {
     assert.notOk(hasRun, 'callback should not have run yet');
-  }, 5);
+  });
 
-  assert.notOk(hasRun, 'callback should not have run yet');
-});
+  test('invokes named functions as async tasks', function(assert) {
+    assert.expect(3);
+    let done = assert.async();
+    let obj = (this.obj = this.subject({
+      run() {
+        hasRun = true;
+        assert.equal(this, obj, 'context is correct');
+        assert.ok(true, 'callback was called');
+        done();
+      },
+    }));
+    let hasRun = false;
 
-test('runTask tasks can be canceled', function(assert) {
-  assert.expect(1);
-  this.obj = this.subject();
-  let done = assert.async();
-  let hasRun = false;
+    runTask(this.obj, 'run', 0);
 
-  let cancelId = runTask(
-    this.obj,
-    () => {
-      hasRun = true;
-    },
-    5
-  );
+    assert.notOk(hasRun, 'callback should not have run yet');
+  });
 
-  cancelTask(cancelId);
+  test('invokes async tasks with delay', function(assert) {
+    assert.expect(3);
+    this.obj = this.subject();
+    let done = assert.async();
+    let hasRun = false;
 
-  window.setTimeout(() => {
+    runTask(
+      this.obj,
+      () => {
+        hasRun = true;
+        assert.ok(true, 'callback was called');
+        done();
+      },
+      10
+    );
+
+    window.setTimeout(() => {
+      assert.notOk(hasRun, 'callback should not have run yet');
+    }, 5);
+
+    assert.notOk(hasRun, 'callback should not have run yet');
+  });
+
+  test('runTask tasks can be canceled', function(assert) {
+    assert.expect(1);
+    this.obj = this.subject();
+    let done = assert.async();
+    let hasRun = false;
+
+    let cancelId = runTask(
+      this.obj,
+      () => {
+        hasRun = true;
+      },
+      5
+    );
+
+    cancelTask(cancelId);
+
+    window.setTimeout(() => {
+      assert.notOk(hasRun, 'callback should have been canceled previously');
+      done();
+    }, 10);
+  });
+
+  test('scheduleTask invokes async tasks', function(assert) {
+    assert.expect(3);
+
+    this.obj = this.subject();
+    let hasRun = false;
+
+    run(() => {
+      scheduleTask(this.obj, 'actions', () => {
+        hasRun = true;
+        assert.ok(true, 'callback was called');
+      });
+
+      assert.notOk(hasRun, 'callback should not have run yet');
+    });
+
+    assert.ok(hasRun, 'callback was called');
+  });
+
+  test('scheduleTask invokes named functions as async tasks', function(assert) {
+    assert.expect(5);
+
+    let obj = (this.obj = this.subject({
+      run(name) {
+        hasRun = true;
+        assert.equal(this, obj, 'context is correct');
+        assert.equal(name, 'foo', 'passed arguments are correct');
+        assert.ok(true, 'callback was called');
+      },
+    }));
+    let hasRun = false;
+
+    run(() => {
+      scheduleTask(this.obj, 'actions', 'run', 'foo');
+      assert.notOk(hasRun, 'callback should not have run yet');
+    });
+
+    assert.ok(hasRun, 'callback was called');
+  });
+
+  test('scheduleTask tasks can be canceled', function(assert) {
+    assert.expect(1);
+    this.obj = this.subject();
+    let hasRun = false;
+
+    run(() => {
+      let timer = scheduleTask(this.obj, 'actions', () => {
+        hasRun = true;
+      });
+
+      cancelTask(timer);
+    });
+
     assert.notOk(hasRun, 'callback should have been canceled previously');
-    done();
-  }, 10);
-});
+  });
 
-test('scheduleTask invokes async tasks', function(assert) {
-  assert.expect(3);
-
-  this.obj = this.subject();
-  let hasRun = false;
-
-  run(() => {
-    scheduleTask(this.obj, 'actions', () => {
-      hasRun = true;
-      assert.ok(true, 'callback was called');
+  test('throttleTask triggers an assertion when a string is not the first argument', function(assert) {
+    this.obj = this.subject({
+      doStuff() {},
     });
 
-    assert.notOk(hasRun, 'callback should not have run yet');
+    assert.throws(() => {
+      throttleTask(this.obj, this.obj.doStuff, 5);
+    }, /without a string as the first argument/);
   });
 
-  assert.ok(hasRun, 'callback was called');
-});
+  test('throttleTask triggers an assertion the function name provided does not exist on the object', function(assert) {
+    this.obj = this.subject();
 
-test('scheduleTask invokes named functions as async tasks', function(assert) {
-  assert.expect(5);
-
-  let obj = (this.obj = this.subject({
-    run(name) {
-      hasRun = true;
-      assert.equal(this, obj, 'context is correct');
-      assert.equal(name, 'foo', 'passed arguments are correct');
-      assert.ok(true, 'callback was called');
-    },
-  }));
-  let hasRun = false;
-
-  run(() => {
-    scheduleTask(this.obj, 'actions', 'run', 'foo');
-    assert.notOk(hasRun, 'callback should not have run yet');
+    assert.throws(() => {
+      throttleTask(this.obj, 'doStuff', 5);
+    }, /is not a function/);
   });
-
-  assert.ok(hasRun, 'callback was called');
-});
-
-test('scheduleTask tasks can be canceled', function(assert) {
-  assert.expect(1);
-  this.obj = this.subject();
-  let hasRun = false;
-
-  run(() => {
-    let timer = scheduleTask(this.obj, 'actions', () => {
-      hasRun = true;
-    });
-
-    cancelTask(timer);
-  });
-
-  assert.notOk(hasRun, 'callback should have been canceled previously');
-});
-
-test('throttleTask triggers an assertion when a string is not the first argument', function(assert) {
-  this.obj = this.subject({
-    doStuff() {},
-  });
-
-  assert.throws(() => {
-    throttleTask(this.obj, this.obj.doStuff, 5);
-  }, /without a string as the first argument/);
-});
-
-test('throttleTask triggers an assertion the function name provided does not exist on the object', function(assert) {
-  this.obj = this.subject();
-
-  assert.throws(() => {
-    throttleTask(this.obj, 'doStuff', 5);
-  }, /is not a function/);
 });

--- a/tests/unit/run-task-test.js
+++ b/tests/unit/run-task-test.js
@@ -13,12 +13,12 @@ module('ember-lifeline/run-task', function(hooks) {
   hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend();
 
-    this.subject = function() {
-      if (this._subject) {
-        return this._subject;
+    this.getComponent = function() {
+      if (this._component) {
+        return this._component;
       }
 
-      return (this._subject = this.BaseObject.create(...arguments));
+      return (this._component = this.BaseObject.create(...arguments));
     };
   });
 
@@ -29,7 +29,7 @@ module('ember-lifeline/run-task', function(hooks) {
   test('invokes async tasks', function(assert) {
     assert.expect(2);
 
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let done = assert.async();
     let hasRun = false;
 
@@ -49,7 +49,7 @@ module('ember-lifeline/run-task', function(hooks) {
   test('invokes named functions as async tasks', function(assert) {
     assert.expect(3);
     let done = assert.async();
-    let obj = (this.obj = this.subject({
+    let obj = (this.obj = this.getComponent({
       run() {
         hasRun = true;
         assert.equal(this, obj, 'context is correct');
@@ -66,7 +66,7 @@ module('ember-lifeline/run-task', function(hooks) {
 
   test('invokes async tasks with delay', function(assert) {
     assert.expect(3);
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let done = assert.async();
     let hasRun = false;
 
@@ -89,7 +89,7 @@ module('ember-lifeline/run-task', function(hooks) {
 
   test('runTask tasks can be canceled', function(assert) {
     assert.expect(1);
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let done = assert.async();
     let hasRun = false;
 
@@ -112,7 +112,7 @@ module('ember-lifeline/run-task', function(hooks) {
   test('scheduleTask invokes async tasks', function(assert) {
     assert.expect(3);
 
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let hasRun = false;
 
     run(() => {
@@ -130,7 +130,7 @@ module('ember-lifeline/run-task', function(hooks) {
   test('scheduleTask invokes named functions as async tasks', function(assert) {
     assert.expect(5);
 
-    let obj = (this.obj = this.subject({
+    let obj = (this.obj = this.getComponent({
       run(name) {
         hasRun = true;
         assert.equal(this, obj, 'context is correct');
@@ -150,7 +150,7 @@ module('ember-lifeline/run-task', function(hooks) {
 
   test('scheduleTask tasks can be canceled', function(assert) {
     assert.expect(1);
-    this.obj = this.subject();
+    this.obj = this.getComponent();
     let hasRun = false;
 
     run(() => {
@@ -165,7 +165,7 @@ module('ember-lifeline/run-task', function(hooks) {
   });
 
   test('throttleTask triggers an assertion when a string is not the first argument', function(assert) {
-    this.obj = this.subject({
+    this.obj = this.getComponent({
       doStuff() {},
     });
 
@@ -175,7 +175,7 @@ module('ember-lifeline/run-task', function(hooks) {
   });
 
   test('throttleTask triggers an assertion the function name provided does not exist on the object', function(assert) {
-    this.obj = this.subject();
+    this.obj = this.getComponent();
 
     assert.throws(() => {
       throttleTask(this.obj, 'doStuff', 5);

--- a/tests/unit/utils/disposable-test.js
+++ b/tests/unit/utils/disposable-test.js
@@ -9,7 +9,7 @@ import {
 
 module('ember-lifeline/utils/disposable', function(hooks) {
   hooks.beforeEach(function() {
-    this.subject = EmberObject.create({
+    this.obj = EmberObject.create({
       destroy() {
         runDisposables(this);
       },
@@ -17,7 +17,7 @@ module('ember-lifeline/utils/disposable', function(hooks) {
   });
 
   hooks.afterEach(function() {
-    run(this.subject, 'destroy');
+    run(this.obj, 'destroy');
   });
 
   test('registerDisposable asserts params are not present', function(assert) {
@@ -35,11 +35,11 @@ module('ember-lifeline/utils/disposable', function(hooks) {
   test('registerDisposable correctly allocates array if not allocated', function(assert) {
     assert.expect(2);
 
-    assert.equal(registeredDisposables.get(this.subject), undefined);
+    assert.equal(registeredDisposables.get(this.obj), undefined);
 
-    registerDisposable(this.subject, function() {});
+    registerDisposable(this.obj, function() {});
 
-    assert.equal(registeredDisposables.get(this.subject).constructor, Array);
+    assert.equal(registeredDisposables.get(this.obj).constructor, Array);
   });
 
   test('registerDisposable adds disposable to disposables', function(assert) {
@@ -47,10 +47,10 @@ module('ember-lifeline/utils/disposable', function(hooks) {
 
     let dispose = () => {};
 
-    registerDisposable(this.subject, dispose);
+    registerDisposable(this.obj, dispose);
 
     assert.equal(
-      registeredDisposables.get(this.subject)[0],
+      registeredDisposables.get(this.obj)[0],
       dispose,
       'dispose function is added to _registeredDisposables'
     );
@@ -61,15 +61,15 @@ module('ember-lifeline/utils/disposable', function(hooks) {
 
     let dispose = () => {};
 
-    registerDisposable(this.subject, dispose);
+    registerDisposable(this.obj, dispose);
 
     assert.equal(
       dispose,
-      registeredDisposables.get(this.subject)[0],
+      registeredDisposables.get(this.obj)[0],
       'disposable is returned'
     );
 
-    let otherDisposable = registerDisposable(this.subject, dispose);
+    let otherDisposable = registerDisposable(this.obj, dispose);
 
     assert.notEqual(dispose, otherDisposable, 'disposable returned is unique');
   });
@@ -86,12 +86,12 @@ module('ember-lifeline/utils/disposable', function(hooks) {
       callCount++;
     };
 
-    registerDisposable(this.subject, dispose);
-    registerDisposable(this.subject, disposeTheSecond);
+    registerDisposable(this.obj, dispose);
+    registerDisposable(this.obj, disposeTheSecond);
 
     assert.equal(callCount, 0, 'two disposables are registered');
 
-    runDisposables(this.subject);
+    runDisposables(this.obj);
 
     assert.equal(callCount, 2, 'no disposables are registered');
   });
@@ -108,14 +108,14 @@ module('ember-lifeline/utils/disposable', function(hooks) {
       callCount++;
     };
 
-    registerDisposable(this.subject, dispose);
-    registerDisposable(this.subject, disposeTheSecond);
+    registerDisposable(this.obj, dispose);
+    registerDisposable(this.obj, disposeTheSecond);
 
-    registeredDisposables.get(this.subject);
+    registeredDisposables.get(this.obj);
 
     assert.equal(callCount, 0, 'two disposables are registered');
 
-    run(this.subject, 'destroy');
+    run(this.obj, 'destroy');
 
     assert.equal(callCount, 2, 'no disposables are registered');
   });

--- a/tests/unit/utils/disposable-test.js
+++ b/tests/unit/utils/disposable-test.js
@@ -7,116 +7,116 @@ import {
   runDisposables,
 } from 'ember-lifeline/utils/disposable';
 
-module('ember-lifeline/utils/disposable', {
-  beforeEach() {
+module('ember-lifeline/utils/disposable', function(hooks) {
+  hooks.beforeEach(function() {
     this.subject = EmberObject.create({
       destroy() {
         runDisposables(this);
       },
     });
-  },
+  });
 
-  afterEach() {
+  hooks.afterEach(function() {
     run(this.subject, 'destroy');
-  },
-});
+  });
 
-test('registerDisposable asserts params are not present', function(assert) {
-  assert.expect(2);
+  test('registerDisposable asserts params are not present', function(assert) {
+    assert.expect(2);
 
-  assert.throws(function() {
-    registerDisposable();
-  }, /Called `registerDisposable` where `obj` is not an object/);
+    assert.throws(function() {
+      registerDisposable();
+    }, /Called `registerDisposable` where `obj` is not an object/);
 
-  assert.throws(function() {
-    registerDisposable({}, null);
-  }, /Called `registerDisposable` where `dispose` is not a function/);
-});
+    assert.throws(function() {
+      registerDisposable({}, null);
+    }, /Called `registerDisposable` where `dispose` is not a function/);
+  });
 
-test('registerDisposable correctly allocates array if not allocated', function(assert) {
-  assert.expect(2);
+  test('registerDisposable correctly allocates array if not allocated', function(assert) {
+    assert.expect(2);
 
-  assert.equal(registeredDisposables.get(this.subject), undefined);
+    assert.equal(registeredDisposables.get(this.subject), undefined);
 
-  registerDisposable(this.subject, function() {});
+    registerDisposable(this.subject, function() {});
 
-  assert.equal(registeredDisposables.get(this.subject).constructor, Array);
-});
+    assert.equal(registeredDisposables.get(this.subject).constructor, Array);
+  });
 
-test('registerDisposable adds disposable to disposables', function(assert) {
-  assert.expect(1);
+  test('registerDisposable adds disposable to disposables', function(assert) {
+    assert.expect(1);
 
-  let dispose = () => {};
+    let dispose = () => {};
 
-  registerDisposable(this.subject, dispose);
+    registerDisposable(this.subject, dispose);
 
-  assert.equal(
-    registeredDisposables.get(this.subject)[0],
-    dispose,
-    'dispose function is added to _registeredDisposables'
-  );
-});
+    assert.equal(
+      registeredDisposables.get(this.subject)[0],
+      dispose,
+      'dispose function is added to _registeredDisposables'
+    );
+  });
 
-test('registerDisposable adds unique disposable to disposables', function(assert) {
-  assert.expect(2);
+  test('registerDisposable adds unique disposable to disposables', function(assert) {
+    assert.expect(2);
 
-  let dispose = () => {};
+    let dispose = () => {};
 
-  registerDisposable(this.subject, dispose);
+    registerDisposable(this.subject, dispose);
 
-  assert.equal(
-    dispose,
-    registeredDisposables.get(this.subject)[0],
-    'disposable is returned'
-  );
+    assert.equal(
+      dispose,
+      registeredDisposables.get(this.subject)[0],
+      'disposable is returned'
+    );
 
-  let otherDisposable = registerDisposable(this.subject, dispose);
+    let otherDisposable = registerDisposable(this.subject, dispose);
 
-  assert.notEqual(dispose, otherDisposable, 'disposable returned is unique');
-});
+    assert.notEqual(dispose, otherDisposable, 'disposable returned is unique');
+  });
 
-test('runDisposables runs all disposables when destroying', function(assert) {
-  assert.expect(2);
+  test('runDisposables runs all disposables when destroying', function(assert) {
+    assert.expect(2);
 
-  let callCount = 0;
+    let callCount = 0;
 
-  let dispose = () => {
-    callCount++;
-  };
-  let disposeTheSecond = () => {
-    callCount++;
-  };
+    let dispose = () => {
+      callCount++;
+    };
+    let disposeTheSecond = () => {
+      callCount++;
+    };
 
-  registerDisposable(this.subject, dispose);
-  registerDisposable(this.subject, disposeTheSecond);
+    registerDisposable(this.subject, dispose);
+    registerDisposable(this.subject, disposeTheSecond);
 
-  assert.equal(callCount, 0, 'two disposables are registered');
+    assert.equal(callCount, 0, 'two disposables are registered');
 
-  runDisposables(this.subject);
+    runDisposables(this.subject);
 
-  assert.equal(callCount, 2, 'no disposables are registered');
-});
+    assert.equal(callCount, 2, 'no disposables are registered');
+  });
 
-test('destroy integration runs all disposables when destroying', function(assert) {
-  assert.expect(2);
+  test('destroy integration runs all disposables when destroying', function(assert) {
+    assert.expect(2);
 
-  let callCount = 0;
+    let callCount = 0;
 
-  let dispose = () => {
-    callCount++;
-  };
-  let disposeTheSecond = () => {
-    callCount++;
-  };
+    let dispose = () => {
+      callCount++;
+    };
+    let disposeTheSecond = () => {
+      callCount++;
+    };
 
-  registerDisposable(this.subject, dispose);
-  registerDisposable(this.subject, disposeTheSecond);
+    registerDisposable(this.subject, dispose);
+    registerDisposable(this.subject, disposeTheSecond);
 
-  registeredDisposables.get(this.subject);
+    registeredDisposables.get(this.subject);
 
-  assert.equal(callCount, 0, 'two disposables are registered');
+    assert.equal(callCount, 0, 'two disposables are registered');
 
-  run(this.subject, 'destroy');
+    run(this.subject, 'destroy');
 
-  assert.equal(callCount, 2, 'no disposables are registered');
+    assert.equal(callCount, 2, 'no disposables are registered');
+  });
 });

--- a/tests/unit/utils/get-task-test.js
+++ b/tests/unit/utils/get-task-test.js
@@ -1,32 +1,32 @@
 import { module, test } from 'qunit';
 import getTask from 'ember-lifeline/utils/get-task';
 
-module('ember-lifeline/utils/get-task');
+module('ember-lifeline/utils/get-task', function() {
+  test('getTask returns passed in task function as task', function(assert) {
+    assert.expect(1);
 
-test('getTask returns passed in task function as task', function(assert) {
-  assert.expect(1);
+    let task = () => {};
 
-  let task = () => {};
+    assert.equal(task, getTask(null, task, 'foo'), 'tasks are equal');
+  });
 
-  assert.equal(task, getTask(null, task, 'foo'), 'tasks are equal');
-});
+  test('getTask returns passed in task from the instance', function(assert) {
+    assert.expect(1);
 
-test('getTask returns passed in task from the instance', function(assert) {
-  assert.expect(1);
+    let instance = { fooTask: () => {} };
 
-  let instance = { fooTask: () => {} };
+    assert.equal(
+      instance.fooTask,
+      getTask(instance, 'fooTask', 'foo'),
+      'tasks are equal'
+    );
+  });
 
-  assert.equal(
-    instance.fooTask,
-    getTask(instance, 'fooTask', 'foo'),
-    'tasks are equal'
-  );
-});
+  test('getTask throws when task not found', function(assert) {
+    assert.expect(1);
 
-test('getTask throws when task not found', function(assert) {
-  assert.expect(1);
-
-  assert.throws(() => {
-    getTask({}, null, 'foo');
-  }, /You must pass a task function or method name to 'foo'./);
+    assert.throws(() => {
+      getTask({}, null, 'foo');
+    }, /You must pass a task function or method name to 'foo'./);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ember/test-helpers@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.18.tgz#a0c474c3029588ec46d2e406252fc072b7f9aa3c"
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.10.0"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
@@ -160,9 +168,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -196,6 +212,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
 arraybuffer.slice@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
@@ -215,6 +235,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 ast-types@0.9.6:
   version "0.9.6"
@@ -259,6 +283,10 @@ async@~0.2.9:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -441,6 +469,12 @@ babel-plugin-ember-modules-api-polyfill@^1.4.1:
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
   dependencies:
     ember-rfc176-data "^0.3.0"
 
@@ -719,6 +753,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -777,6 +818,18 @@ base64-arraybuffer@0.1.5:
 base64id@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-0.1.0.tgz#02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 basic-auth@~1.1.0:
   version "1.1.0"
@@ -863,6 +916,23 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+braces@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    kind-of "^6.0.2"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
 
 broccoli-asset-rev@^2.4.5:
   version "2.5.0"
@@ -1232,6 +1302,20 @@ bytes@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
 
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
 calculate-cache-key-for-tree@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz#0c3e42c9c134f3c9de5358c0f16793627ea976d6"
@@ -1328,9 +1412,9 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
-chokidar@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
+chokidar@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
     anymatch "^1.3.0"
     async-each "^1.0.0"
@@ -1350,6 +1434,15 @@ ci-info@^1.0.0:
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 clean-base-url@^1.0.0:
   version "1.0.0"
@@ -1426,6 +1519,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
 color-convert@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
@@ -1456,21 +1556,31 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@2.9.0, commander@^2.6.0:
+commander@^2.11.0, commander@^2.9.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+
+commander@^2.6.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.11.0, commander@^2.9.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+common-tags@^1.4.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
+  dependencies:
+    babel-runtime "^6.26.0"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -1480,7 +1590,7 @@ component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
 
-component-emitter@1.2.1:
+component-emitter@1.2.1, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -1576,6 +1686,10 @@ copy-dereference@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/copy-dereference/-/copy-dereference-1.0.0.tgz#6b131865420fd81b413ba994b44d3655311152b6"
 
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -1669,6 +1783,12 @@ debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.
   dependencies:
     ms "2.0.0"
 
+debug@^2.3.3:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -1678,6 +1798,10 @@ debug@^3.1.0:
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -1690,6 +1814,25 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 del@^2.0.2:
   version "2.2.2"
@@ -1724,6 +1867,10 @@ detect-file@^0.1.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
   dependencies:
     fs-exists-sync "^0.1.0"
+
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -1797,6 +1944,24 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
+ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.8.1:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.3.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
+
 ember-cli-babel@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
@@ -1856,6 +2021,16 @@ ember-cli-htmlbars-inline-precompile@^0.4.3:
     babel-plugin-htmlbars-inline-precompile "^0.2.3"
     ember-cli-version-checker "^2.0.0"
     hash-for-dep "^1.0.2"
+    silent-error "^1.1.0"
+
+ember-cli-htmlbars-inline-precompile@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz#5b544f664d5d9911f08cd979c5f70d8cb0ca2add"
+  dependencies:
+    babel-plugin-htmlbars-inline-precompile "^0.2.3"
+    ember-cli-version-checker "^2.0.0"
+    hash-for-dep "^1.0.2"
+    heimdalljs-logger "^0.1.7"
     silent-error "^1.1.0"
 
 ember-cli-htmlbars@^2.0.1:
@@ -1924,20 +2099,12 @@ ember-cli-preprocess-registry@^3.1.0:
     process-relative-require "^1.0.0"
     silent-error "^1.0.0"
 
-ember-cli-qunit@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.0.0.tgz#1f0022469a5bd64f627b8102880a25e94e533a3b"
+ember-cli-qunit@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.3.2.tgz#cfd89ad3b0dbc28a9c2223d532b52eeade7c602c"
   dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0-beta.7"
-    ember-cli-test-loader "^2.0.0"
-    ember-cli-version-checker "^1.1.4"
-    ember-qunit "^2.1.3"
-    qunit-notifications "^0.1.1"
-    qunitjs "^2.0.1"
-    resolve "^1.1.6"
-    silent-error "^1.0.0"
+    ember-cli-babel "^6.11.0"
+    ember-qunit "^3.3.2"
 
 ember-cli-release@^0.2.9:
   version "0.2.9"
@@ -1977,11 +2144,11 @@ ember-cli-test-info@^1.0.0:
   dependencies:
     ember-cli-string-utils "^1.0.0"
 
-ember-cli-test-loader@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.1.0.tgz#16163bae0ac32cad1af13c4ed94c6c698b54d431"
+ember-cli-test-loader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
   dependencies:
-    ember-cli-babel "^6.0.0-beta.7"
+    ember-cli-babel "^6.8.1"
 
 ember-cli-uglify@^1.2.0:
   version "1.2.0"
@@ -1995,7 +2162,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@1.3.1, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
+ember-cli-version-checker@1.3.1, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2137,11 +2304,17 @@ ember-native-dom-helpers@0.5.2:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.1.0"
 
-ember-qunit@^2.1.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.2.0.tgz#3cdf400031c93a38de781a7304819738753b7f99"
+ember-qunit@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.3.2.tgz#cb48e9deaffa3b4c90983f28c5cf8590894c8ea3"
   dependencies:
-    ember-test-helpers "^0.6.3"
+    "@ember/test-helpers" "^0.7.18"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    common-tags "^1.4.0"
+    ember-cli-babel "^6.3.0"
+    ember-cli-test-loader "^2.2.0"
+    qunit "^2.5.0"
 
 ember-resolver@^4.0.0:
   version "4.3.0"
@@ -2187,10 +2360,6 @@ ember-source@~2.18.0:
     inflection "^1.12.0"
     jquery "^3.2.1"
     resolve "^1.3.3"
-
-ember-test-helpers@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
 ember-try-config@^2.0.1:
   version "2.1.0"
@@ -2540,6 +2709,18 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -2551,6 +2732,12 @@ expand-tilde@^1.2.2:
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
   dependencies:
     os-homedir "^1.0.1"
+
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
 
 express@^4.10.7, express@^4.12.3:
   version "4.15.3"
@@ -2585,6 +2772,19 @@ express@^4.10.7, express@^4.12.3:
     utils-merge "1.0.0"
     vary "~1.1.1"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -2602,6 +2802,19 @@ extglob@^0.3.1:
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extsprintf@1.0.2:
   version "1.0.2"
@@ -2678,6 +2891,15 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 finalhandler@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
@@ -2704,7 +2926,16 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-findup-sync@0.4.3, findup-sync@^0.4.2:
+findup-sync@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^3.1.0"
+    micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
+
+findup-sync@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
   dependencies:
@@ -2732,7 +2963,7 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -2761,6 +2992,12 @@ form-data@~2.1.1:
 forwarded@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
 
 fresh@0.5.0:
   version "0.5.0"
@@ -2919,6 +3156,10 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -2987,6 +3228,14 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -2995,6 +3244,16 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 globals@^9.0.0, globals@^9.14.0:
   version "9.18.0"
@@ -3080,6 +3339,33 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
 hash-for-dep@^1.0.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.1.2.tgz#e3347ed92960eb0bb53a2c6c2b70e36d75b7cd0c"
@@ -3133,7 +3419,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0:
+homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -3281,6 +3567,18 @@ ipaddr.js@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3301,6 +3599,34 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.0.0"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
 is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
@@ -3315,15 +3641,21 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-extglob@^2.1.1:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -3353,6 +3685,12 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  dependencies:
+    is-extglob "^2.1.0"
+
 is-glob@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
@@ -3380,6 +3718,10 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
 is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
@@ -3389,6 +3731,12 @@ is-observable@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
   dependencies:
     symbol-observable "^0.2.2"
+
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
+  dependencies:
+    is-number "^4.0.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -3405,6 +3753,12 @@ is-path-inside@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -3450,6 +3804,10 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
+is-windows@^1.0.1, is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -3471,6 +3829,10 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3505,9 +3867,9 @@ jquery@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
-js-reporters@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.0.tgz#7cf2cb698196684790350d0c4ca07f4aed9ec17e"
+js-reporters@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.1.tgz#f88c608e324a3373a95bcc45ad305e5c979c459b"
 
 js-tokens@^3.0.0:
   version "3.0.2"
@@ -3605,7 +3967,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -3617,6 +3979,14 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -3626,6 +3996,12 @@ klaw@^1.0.0:
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-cache@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  dependencies:
+    set-getter "^0.1.0"
 
 leek@0.0.24:
   version "0.0.24"
@@ -3924,6 +4300,16 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
 markdown-it-terminal@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it-terminal/-/markdown-it-terminal-0.1.0.tgz#545abd8dd01c3d62353bfcea71db580b51d22bd9"
@@ -4015,6 +4401,24 @@ micromatch@^2.1.5, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+micromatch@^3.0.4:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 "mime-db@>= 1.27.0 < 2", mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
@@ -4042,6 +4446,13 @@ minimist@0.0.8, minimist@~0.0.1:
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
 
 mkdirp@0.3.x, mkdirp@~0.3.5:
   version "0.3.5"
@@ -4108,6 +4519,23 @@ mute-stream@0.0.6:
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4238,12 +4666,32 @@ object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -4374,6 +4822,10 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -4435,6 +4887,10 @@ portfinder@^1.0.7:
     async "^1.5.2"
     debug "^2.2.0"
     mkdirp "0.5.x"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -4510,21 +4966,18 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit-notifications@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/qunit-notifications/-/qunit-notifications-0.1.1.tgz#3001afc6a6a77dfbd962ccbcddde12dec5286c09"
-
-qunitjs@^2.0.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.0.tgz#58f3a81e846687f2e7f637c5bedc9c267f887261"
+qunit@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.5.0.tgz#64cbe30a1193ef02edc5b278efcdf1d0bae96b22"
   dependencies:
-    chokidar "1.6.1"
-    commander "2.9.0"
+    chokidar "1.7.0"
+    commander "2.12.2"
     exists-stat "1.0.0"
-    findup-sync "0.4.3"
-    js-reporters "1.2.0"
-    resolve "1.3.2"
-    walk-sync "0.3.1"
+    findup-sync "2.0.0"
+    js-reporters "1.2.1"
+    resolve "1.5.0"
+    shelljs "^0.2.6"
+    walk-sync "0.3.2"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -4620,6 +5073,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -4638,6 +5095,13 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
+
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
 regexpu-core@^2.0.0:
   version "2.0.0"
@@ -4665,7 +5129,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -4728,13 +5192,24 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
+resolve@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
 
@@ -4750,6 +5225,10 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -4809,6 +5288,12 @@ safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
 
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
+
 sane@^1.1.1, sane@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.7.0.tgz#b3579bccb45c94cf20355cc81124990dfd346e30"
@@ -4828,6 +5313,10 @@ semver@^4.1.0, semver@^4.3.1:
 semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 send@0.15.3:
   version "0.15.3"
@@ -4860,9 +5349,33 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  dependencies:
+    to-object-path "^0.3.0"
+
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setprototypeof@1.0.3:
   version "1.0.3"
@@ -4877,6 +5390,10 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shelljs@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.2.6.tgz#90492d72ffcc8159976baba62fb0f6884f0c3378"
 
 shelljs@^0.7.5:
   version "0.7.8"
@@ -4911,6 +5428,33 @@ slice-ansi@0.0.4:
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.1.tgz#e12b5487faded3e3dea0ac91e9400bf75b401370"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^2.0.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -4972,6 +5516,16 @@ sort-package-json@^1.4.0:
   dependencies:
     sort-object-keys "^1.1.1"
 
+source-map-resolve@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  dependencies:
+    atob "^2.0.0"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
@@ -4981,6 +5535,10 @@ source-map-support@^0.4.2:
 source-map-url@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
@@ -5007,6 +5565,12 @@ spawnback@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/spawnback/-/spawnback-1.0.0.tgz#f73662f7e54d95367eca74d6426c677dd7ea686f"
 
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
+
 sprintf-js@^1.0.3, sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -5032,6 +5596,13 @@ sshpk@^1.7.0:
 staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
@@ -5279,6 +5850,28 @@ to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -5366,6 +5959,15 @@ underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 unique-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
@@ -5380,11 +5982,30 @@ unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
 untildify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
   dependencies:
     os-homedir "^1.0.0"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+use@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"
+  dependencies:
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    lazy-cache "^2.0.2"
 
 user-home@^2.0.0:
   version "2.0.0"
@@ -5424,9 +6045,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-walk-sync@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.1.tgz#558a16aeac8c0db59c028b73c66f397684ece465"
+walk-sync@0.3.2, walk-sync@^0.3.0, walk-sync@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
@@ -5438,13 +6059,6 @@ walk-sync@^0.1.3:
 walk-sync@^0.2.5, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
-  dependencies:
-    ensure-posix-path "^1.0.0"
-    matcher-collection "^1.0.0"
-
-walk-sync@^0.3.0, walk-sync@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
@@ -5475,7 +6089,7 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
-which@^1.2.10:
+which@^1.2.10, which@^1.2.14:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,85 +2,15 @@
 # yarn lockfile v1
 
 
-"@glimmer/compiler@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.22.3.tgz#3aef9448460af1d320a82423323498a6ff38a0c6"
-  dependencies:
-    "@glimmer/syntax" "^0.22.3"
-    "@glimmer/util" "^0.22.3"
-    "@glimmer/wire-format" "^0.22.3"
-    simple-html-tokenizer "^0.3.0"
-
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
-
-"@glimmer/interfaces@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.22.3.tgz#1c2e3289ae41a750f0c8ddcc64529b9e90dda604"
-  dependencies:
-    "@glimmer/wire-format" "^0.22.3"
-
-"@glimmer/node@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.22.3.tgz#ff33eea6e65147a20c1bd1f05fdc4a6c3595c54c"
-  dependencies:
-    "@glimmer/runtime" "^0.22.3"
-    simple-dom "^0.3.0"
-
-"@glimmer/object-reference@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/object-reference/-/object-reference-0.22.3.tgz#31db68c8912324c63509b1ef83213f7ad4ef312b"
-  dependencies:
-    "@glimmer/reference" "^0.22.3"
-    "@glimmer/util" "^0.22.3"
-
-"@glimmer/object@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/object/-/object-0.22.3.tgz#1fc9fd7465c7d12e5b92464ad40038b595de8ed0"
-  dependencies:
-    "@glimmer/object-reference" "^0.22.3"
-    "@glimmer/util" "^0.22.3"
-
-"@glimmer/reference@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.22.3.tgz#6f2ef8cd97fe756d89fef75f8c3c79003502a2a9"
-  dependencies:
-    "@glimmer/util" "^0.22.3"
 
 "@glimmer/resolver@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.1.tgz#cd9644572c556e7e799de1cf8eff2b999cf5b878"
   dependencies:
     "@glimmer/di" "^0.2.0"
-
-"@glimmer/runtime@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.22.3.tgz#b8cb28efc9cc86c406ee996f5c2cf6730620d404"
-  dependencies:
-    "@glimmer/interfaces" "^0.22.3"
-    "@glimmer/object" "^0.22.3"
-    "@glimmer/object-reference" "^0.22.3"
-    "@glimmer/reference" "^0.22.3"
-    "@glimmer/util" "^0.22.3"
-    "@glimmer/wire-format" "^0.22.3"
-
-"@glimmer/syntax@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.22.3.tgz#8528d19324bf7f920f5cfd31925e452e51781b44"
-  dependencies:
-    handlebars "^4.0.6"
-    simple-html-tokenizer "^0.3.0"
-
-"@glimmer/util@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.22.3.tgz#8272f50905d1bb904ee371e8ade83fd779b51508"
-
-"@glimmer/wire-format@^0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.22.3.tgz#19b226d9b93ba6ee54472d9ffb1d48e7c0d80a0d"
-  dependencies:
-    "@glimmer/util" "^0.22.3"
 
 abbrev@1:
   version "1.1.0"
@@ -1090,7 +1020,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1099,6 +1029,24 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli
     broccoli-plugin "^1.3.0"
     debug "^2.2.0"
     exists-sync "0.0.4"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
+broccoli-funnel@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
     fast-ordered-set "^1.0.0"
     fs-tree-diff "^0.5.3"
     heimdalljs "^0.2.0"
@@ -2060,6 +2008,13 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~2.14.0-beta.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.14.1.tgz#22b5da78f85d72bff7e2e790fcf6b202c793f263"
@@ -2208,36 +2163,30 @@ ember-rfc176-data@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.0.tgz#6aee728cb521c5f80710990965027b9c320f6f08"
 
-ember-router-generator@^1.0.0:
+ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
   dependencies:
     recast "^0.11.3"
 
-ember-source@~2.14.0-beta.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.14.1.tgz#4abf0b4c916f2da8bf317349df4750905df7e628"
+ember-source@~2.18.0:
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.18.2.tgz#75d00eef5488bfe504044b025c752ba924eaf87f"
   dependencies:
-    "@glimmer/compiler" "^0.22.3"
-    "@glimmer/node" "^0.22.3"
-    "@glimmer/reference" "^0.22.3"
-    "@glimmer/runtime" "^0.22.3"
-    "@glimmer/util" "^0.22.3"
-    broccoli-funnel "^1.2.0"
+    broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
     ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-valid-component-name "^1.0.0"
-    ember-cli-version-checker "^1.3.1"
-    handlebars "^4.0.6"
+    ember-cli-version-checker "^2.1.0"
+    ember-router-generator "^1.2.3"
+    inflection "^1.12.0"
     jquery "^3.2.1"
     resolve "^1.3.3"
-    rsvp "^3.5.0"
-    simple-dom "^0.3.0"
-    simple-html-tokenizer "^0.4.1"
 
 ember-test-helpers@^0.6.3:
   version "0.6.3"
@@ -3074,7 +3023,7 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
-handlebars@^4.0.4, handlebars@^4.0.6:
+handlebars@^4.0.4:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
   dependencies:
@@ -3252,7 +3201,7 @@ indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
-inflection@^1.7.0, inflection@^1.7.1:
+inflection@^1.12.0, inflection@^1.7.0, inflection@^1.7.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
 
@@ -4950,18 +4899,6 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.1.0.tgz#2209706f1c850a9f1d10d0d840918b46f26e1bc9"
   dependencies:
     debug "^2.2.0"
-
-simple-dom@^0.3.0:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/simple-dom/-/simple-dom-0.3.2.tgz#0663d10f1556f1500551d518f56e3aba0871371d"
-
-simple-html-tokenizer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz#9b8b5559d80e331a544dd13dd59382e5d0d94411"
-
-simple-html-tokenizer@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz#028988bb7fe8b2e6645676d82052587d440b02d3"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR represents the last part of porting lifeline to leveraging WeakMap instead of instance arrays.

TODO:

- [x] Convert `ContextBoundEventListenersMixin` to use `registerDisposable` instead of instance array
  - [x] `addEventListener`
  - [x] `removeEventListener`
- [x] Correctly divide responsibilities between mixin and util
- [x] Convert tests to new structure
- [x]  Add tests for DOM util
- [x] Make tests pass