### PR TITLE
Adding test support to ensure disposables have been run.

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,28 @@
+import QUnit from 'qunit';
+import { hasRunAllDisposables } from 'ember-lifeline';
+
+const FAILED_ASSERTION_MESSAGE =
+  'One or more objects registered disposables that were not correctly disposed of. Please ensure that objects correctly run their registered disposables by calling `runDisposables` in the `destroy` method of the object.';
+let setupTestDone = false;
+
+export default function setupEnsureLifelineDisposablesRun(hooks) {
+  if (!setupTestDone) {
+    QUnit.testDone(ensureDisposablesRunIfNoFailures);
+
+    setupTestDone = true;
+  }
+
+  hooks.afterEach(ensureDisposablesRun);
+}
+
+export function ensureDisposablesRunIfNoFailures(details) {
+  if (details.failed === 0) {
+    ensureDisposablesRun();
+  }
+}
+
+export function ensureDisposablesRun() {
+  if (!hasRunAllDisposables()) {
+    QUnit.assert.ok(false, FAILED_ASSERTION_MESSAGE);
+  }
+}

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,11 +1,13 @@
-import QUnit from 'qunit';
+import require from 'require';
 import { hasRunAllDisposables } from 'ember-lifeline';
+
+let QUnit = require('qunit').default;
 
 const FAILED_ASSERTION_MESSAGE =
   'One or more objects registered disposables that were not correctly disposed of. Please ensure that objects correctly run their registered disposables by calling `runDisposables` in the `destroy` method of the object.';
 let setupTestDone = false;
 
-export default function setupEnsureLifelineDisposablesRun(hooks) {
+export default function setupLifelineValidation(hooks) {
   if (!setupTestDone) {
     QUnit.testDone(ensureDisposablesRunIfNoFailures);
 
@@ -16,8 +18,8 @@ export default function setupEnsureLifelineDisposablesRun(hooks) {
 }
 
 export function ensureDisposablesRunIfNoFailures(details) {
-  if (details.failed === 0) {
-    ensureDisposablesRun();
+  if (details.failed === 0 && !hasRunAllDisposables()) {
+    throw new Error(FAILED_ASSERTION_MESSAGE);
   }
 }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,7 +2,11 @@ export { runTask, scheduleTask, throttleTask, cancelTask } from './run-task';
 export { pollTask, pollTaskFor, setShouldPoll, cancelPoll } from './poll-task';
 export { debounceTask, cancelDebounce } from './debounce-task';
 export { addEventListener, removeEventListener } from './dom-event-listeners';
-export { runDisposables, hasRunAllDisposables } from './utils/disposable';
+export {
+  registerDisposable,
+  runDisposables,
+  _setRegisteredDisposables,
+} from './utils/disposable';
 
 export { ContextBoundTasksMixin } from './mixins/run';
 export { ContextBoundEventListenersMixin } from './mixins/dom';

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,7 +2,7 @@ export { runTask, scheduleTask, throttleTask, cancelTask } from './run-task';
 export { pollTask, pollTaskFor, setShouldPoll, cancelPoll } from './poll-task';
 export { debounceTask, cancelDebounce } from './debounce-task';
 export { addEventListener, removeEventListener } from './dom-event-listeners';
-export { runDisposables } from './utils/disposable';
+export { runDisposables, hasRunAllDisposables } from './utils/disposable';
 
 export { ContextBoundTasksMixin } from './mixins/run';
 export { ContextBoundEventListenersMixin } from './mixins/dom';

--- a/addon/utils/disposable.js
+++ b/addon/utils/disposable.js
@@ -3,6 +3,8 @@ import { assert } from '@ember/debug';
 
 const { WeakMap } = Ember;
 
+let totalRegisteredDisposables = 0;
+
 /**
  * A map of instances/array of disposables. Only exported for
  * testing purposes.
@@ -36,6 +38,7 @@ export function registerDisposable(obj, dispose) {
   let disposables = getRegisteredDisposables(obj);
 
   disposables.push(dispose);
+  totalRegisteredDisposables++;
 }
 
 /**
@@ -55,7 +58,21 @@ export function runDisposables(obj) {
 
   for (let i = 0; i < disposables.length; i++) {
     disposables[i]();
+    totalRegisteredDisposables--;
   }
+}
+
+/**
+  Checks whether all registered disposables have been run or not.
+
+  Run means that each disposable has been executed via the `runDisposables`
+  function against an object instance.
+
+  @public
+  @returns {boolean} `true` if all disposables are run, `false` otherwise
+*/
+export function hasRunAllDisposables() {
+  return totalRegisteredDisposables === 0;
 }
 
 function getRegisteredDisposables(obj) {

--- a/tests/unit/dom-event-listeners-test.js
+++ b/tests/unit/dom-event-listeners-test.js
@@ -40,10 +40,6 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
       : this.owner._lookupFactory(name);
   });
 
-  hooks.afterEach(function() {
-    runDisposables(this.componentInstance);
-  });
-
   [
     {
       testName: 'addEventListener(_,_,_,undefined)',
@@ -271,9 +267,6 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
 
       target.click();
       assert.equal(calls, 3, 'one more callback called for remaining context');
-
-      run(subjectA, 'destroy');
-      run(subjectB, 'destroy');
     });
 
     test(`${testName} listeners are called with correct scope`, async function(assert) {
@@ -337,10 +330,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
         testedOptions
       );
 
-      await triggerEvent(target, 'click');
-
-      run(subjectA, 'destroy');
-      run(subjectB, 'destroy');
+      target.click();
     });
 
     test(`${testName.replace(
@@ -428,8 +418,6 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
         1,
         'callback is not called again once the instance is destroyed'
       );
-
-      run(service, 'destroy');
     });
   });
 

--- a/tests/unit/dom-event-listeners-test.js
+++ b/tests/unit/dom-event-listeners-test.js
@@ -40,6 +40,10 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
       : this.owner._lookupFactory(name);
   });
 
+  hooks.afterEach(function() {
+    runDisposables(this.componentInstance);
+  });
+
   [
     {
       testName: 'addEventListener(_,_,_,undefined)',
@@ -267,6 +271,9 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
 
       target.click();
       assert.equal(calls, 3, 'one more callback called for remaining context');
+
+      run(subjectA, 'destroy');
+      run(subjectB, 'destroy');
     });
 
     test(`${testName} listeners are called with correct scope`, async function(assert) {
@@ -330,7 +337,10 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
         testedOptions
       );
 
-      target.click();
+      await triggerEvent(target, 'click');
+
+      run(subjectA, 'destroy');
+      run(subjectB, 'destroy');
     });
 
     test(`${testName.replace(
@@ -418,6 +428,8 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
         1,
         'callback is not called again once the instance is destroyed'
       );
+
+      run(service, 'destroy');
     });
   });
 

--- a/tests/unit/poll-task-test.js
+++ b/tests/unit/poll-task-test.js
@@ -14,7 +14,11 @@ import { settled } from '@ember/test-helpers';
 
 module('ember-lifeline/poll-task', function(hooks) {
   hooks.beforeEach(function() {
-    this.BaseObject = EmberObject.extend();
+    this.BaseObject = EmberObject.extend({
+      destroy() {
+        runDisposables(this);
+      },
+    });
 
     this.getComponent = function({ force } = {}) {
       if (force && this._component) {
@@ -31,7 +35,7 @@ module('ember-lifeline/poll-task', function(hooks) {
   });
 
   hooks.afterEach(function() {
-    runDisposables(this.obj);
+    run(this.obj, 'destroy');
     setShouldPoll(null);
   });
 

--- a/tests/unit/setup-lifeline-validation-test.js
+++ b/tests/unit/setup-lifeline-validation-test.js
@@ -1,0 +1,34 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupLifelineValidation from 'ember-lifeline/test-support';
+import { registerDisposable } from 'ember-lifeline';
+
+module('setupLifelineValidation', function(hooks) {
+  setupLifelineValidation(hooks);
+  setupTest(hooks);
+
+  hooks.beforeEach(function(assert) {
+    let originalPushResult = assert.pushResult;
+    assert.pushResult = function(resultInfo) {
+      // Inverts the result so we can test failing assertions
+      resultInfo.result = !resultInfo.result;
+      resultInfo.message = `Failed: ${resultInfo.message}`;
+      originalPushResult(resultInfo);
+    };
+
+    let serviceName = 'service:under-test';
+    this.owner.register(serviceName, Service.extend());
+    let factory = this.owner.factoryFor
+      ? this.owner.factoryFor(serviceName)
+      : this.owner._lookupFactory(serviceName);
+
+    this.service = factory.create();
+  });
+
+  test('setupLifelineValidation fails when registeredDisposables is not cleared', function(assert) {
+    assert.expect(1);
+
+    registerDisposable(this.service, () => {});
+  });
+});

--- a/tests/unit/utils/disposable-test.js
+++ b/tests/unit/utils/disposable-test.js
@@ -34,6 +34,8 @@ module('ember-lifeline/utils/disposable', function(hooks) {
       [],
       'Registered disposables should be empty'
     );
+
+    _setRegisteredDisposables(new WeakMap());
   });
 
   hooks.after(function() {

--- a/tests/unit/utils/disposable-test.js
+++ b/tests/unit/utils/disposable-test.js
@@ -5,6 +5,7 @@ import {
   registeredDisposables,
   registerDisposable,
   runDisposables,
+  hasRunAllDisposables,
 } from 'ember-lifeline/utils/disposable';
 
 module('ember-lifeline/utils/disposable', function(hooks) {
@@ -118,5 +119,25 @@ module('ember-lifeline/utils/disposable', function(hooks) {
     run(this.obj, 'destroy');
 
     assert.equal(callCount, 2, 'no disposables are registered');
+  });
+
+  test('hasRunAllDisposables returns false if all disposables have not run', function(assert) {
+    assert.expect(1);
+
+    registerDisposable(this.obj, () => {});
+
+    assert.equal(hasRunAllDisposables(), false, 'disposables have not run');
+  });
+
+  test('hasRunAllDisposables returns true if all disposables have run', function(assert) {
+    assert.expect(2);
+
+    registerDisposable(this.obj, () => {});
+
+    assert.notOk(hasRunAllDisposables(), 'disposables have not run');
+
+    run(this.obj, 'destroy');
+
+    assert.ok(hasRunAllDisposables(), 'disposables have run');
   });
 });

--- a/tests/unit/utils/disposable-test.js
+++ b/tests/unit/utils/disposable-test.js
@@ -36,6 +36,10 @@ module('ember-lifeline/utils/disposable', function(hooks) {
     );
   });
 
+  hooks.after(function() {
+    _setRegisteredDisposables(new WeakMap());
+  });
+
   test('registerDisposable asserts params are not present', function(assert) {
     assert.expect(4);
 


### PR DESCRIPTION
With the new functional API, users of the library run `registerDisposable` in order to queue a disposable to run. They're then required to ensure that `runDisposables` is called at some point during the destruction phase. Currently, there's no way to ensure that users correctly implement their objects in such a way as to guarantee that disposables are called. When not implemented, this library becomes useless.

As a way to help ensure disposables are called, this PR introduces a test helper which, when setup in your tests, will hook into QUnit's `afterEach` and `testDone` respectively and ensure you don't have any disposables that haven't run. 

- Adding refcounter for disposables to ensure they run. 
- Added tests. 
- Added test integration