### PR TITLE
Look for a string when asserting something is an element

### DIFF
--- a/addon/dom-event-listeners.js
+++ b/addon/dom-event-listeners.js
@@ -144,7 +144,13 @@ export function removeEventListener(
 
 function assertArguments(element, eventName, callback) {
   assert('Must provide a DOM element', !!element);
-  assert('Must provide an element (not a DOM selector)', !!element.nodeType);
+  assert(
+    'Must provide an element (not a DOM selector)',
+    typeof element !== 'string' &&
+      typeof element !== 'function' &&
+      element !== null &&
+      element !== undefined
+  );
   assert(
     'Must provide an eventName that specifies the event type',
     !!eventName

--- a/tests/unit/dom-event-listeners-test.js
+++ b/tests/unit/dom-event-listeners-test.js
@@ -177,7 +177,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
     });
 
     test(`${testName} throws when called with incorrect arguments`, async function(assert) {
-      assert.expect(4);
+      assert.expect(5);
 
       await render(hbs`{{under-test}}`);
       let component = this.componentInstance;
@@ -187,7 +187,11 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
       }, /Must provide a DOM element/);
 
       assert.throws(() => {
-        addEventListener(component, {}, 'click', () => {}, testedOptions);
+        addEventListener(component, '.el', 'click', () => {}, testedOptions);
+      }, /Must provide an element \(not a DOM selector\)/);
+
+      assert.throws(() => {
+        addEventListener(component, () => {}, 'click', () => {}, testedOptions);
       }, /Must provide an element \(not a DOM selector\)/);
 
       assert.throws(() => {
@@ -479,5 +483,23 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
 
     await triggerEvent(element, 'click');
     assert.equal(calls, 1, 'callback was called once');
+  });
+
+  test('addEventListener to window', async function(assert) {
+    assert.expect(1);
+
+    this.owner.register('template:components/under-test', hbs`<span></span>`);
+    await render(hbs`{{under-test}}`);
+    let component = this.componentInstance;
+
+    let calls = 0;
+    let listener = () => {
+      calls++;
+    };
+
+    addEventListener(component, window, 'click', listener);
+
+    await triggerEvent(window, 'click');
+    assert.equal(calls, 1, 'callback was called');
   });
 });


### PR DESCRIPTION
nodeType does not exist on the window object so this assertion needs to
be relaxed a little in order to allow adding listeners to window. Fixes #70



I'm not sure this assertion needs to be relaxed *this much*, but this seemed cleaner than implementing a complicated duck type test since it will catch any common mistake given that we can't use `instanceof Element` https://github.com/rwjblue/ember-lifeline/pull/67#discussion_r171745877