### PR TITLE
Exit cancelDebounce if task is no longer pending

### DIFF
--- a/addon/debounce-task.js
+++ b/addon/debounce-task.js
@@ -123,7 +123,7 @@ export function debounceTask(obj, name, ...debounceArgs) {
 export function cancelDebounce(obj, name) {
   let pendingDebounces = registeredDebounces.get(obj);
 
-  if (!pendingDebounces || !pendingDebounces[name]) {
+  if (pendingDebounces === undefined || pendingDebounces[name] === undefined) {
     return;
   }
 

--- a/addon/debounce-task.js
+++ b/addon/debounce-task.js
@@ -123,7 +123,7 @@ export function debounceTask(obj, name, ...debounceArgs) {
 export function cancelDebounce(obj, name) {
   let pendingDebounces = registeredDebounces.get(obj);
 
-  if (pendingDebounces === undefined) {
+  if (!pendingDebounces || !pendingDebounces[name]) {
     return;
   }
 

--- a/tests/unit/debounce-task-test.js
+++ b/tests/unit/debounce-task-test.js
@@ -68,4 +68,33 @@ module('ember-lifeline/debounce-task', function(hooks) {
       done();
     }, 10);
   });
+
+  test('cancelDebounce does not throw an error if the debounced task was never run', function(assert) {
+    assert.expect(1);
+
+    this.obj = this.getComponent({
+      doStuff() {},
+    });
+
+    cancelDebounce(this.obj, 'doStuff');
+
+    assert.ok(true, 'should not have thrown an error');
+  });
+
+  test('cancelDebounce does not throw an error if the debounced task is no longer pending', function(assert) {
+    let done = assert.async();
+    assert.expect(1);
+
+    this.obj = this.getComponent({
+      doStuff() {},
+    });
+
+    debounceTask(this.obj, 'doStuff', 5);
+
+    window.setTimeout(() => {
+      cancelDebounce(this.obj, 'doStuff');
+      assert.ok(true, 'should not have thrown an error');
+      done();
+    }, 10);
+  });
 });


### PR DESCRIPTION
Fixes the following issue:
1. Trigger a debounced task and wait for it to finish running.
2. Perform some other action in the UI that cancels any debounced tasks that might be running.
Expected Result: Nothing happens, since there is nothing to cancel
Actual Result: `TypeError: Cannot read property 'cancelId' of undefined`